### PR TITLE
Add tests and fix for wildcard search with case insensitivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8464,7 +8464,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -14087,7 +14088,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -29670,7 +29672,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -96,8 +96,8 @@ const searchWithMismatch = (query, subject, mismatch, fwd) => {
     let missed = 0;
 
     for (let j = 0; j < query.length; j += 1) {
-      const targetChar = subject[i + j];
-      const queryChar = query[j];
+      const targetChar = subject[i + j].toLowerCase();
+      const queryChar = query[j].toLowerCase();
       if (nucleotides[queryChar]) {
         if (targetChar !== queryChar) {
           missed += 1;

--- a/src/utils/search.test.js
+++ b/src/utils/search.test.js
@@ -16,6 +16,52 @@ describe("Search", () => {
     });
   });
 
+  it("finds subsequence without mismatch or ambiguity, uppercase query", () => {
+    const query = "TATT";
+    const subject = "gcgagttattcggcgtgg";
+    const mismatch = 0;
+
+    const results = search(query, mismatch, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 6,
+      end: 10,
+      direction: 1
+    });
+  });
+
+  /* test a full range of casing possibilities for one mismatch=0, no wildcards */
+  it("finds subsequence without mismatch or ambiguity, uppercase subject", () => {
+    const query = "tatt";
+    const subject = "GCGAGTTATTCGGCGTGG";
+    const mismatch = 0;
+
+    const results = search(query, mismatch, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 6,
+      end: 10,
+      direction: 1
+    });
+  });
+
+  it("finds subsequence without mismatch or ambiguity, uppercase both", () => {
+    const query = "TATT";
+    const subject = "GCGAGTTATTCGGCGTGG";
+    const mismatch = 0;
+
+    const results = search(query, mismatch, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 6,
+      end: 10,
+      direction: 1
+    });
+  });
+
   it("finds subsequence without mismatch or ambiguity in RC", () => {
     const query = "aata";
     const subject = "gcgagttattcggcgtgg";
@@ -46,6 +92,52 @@ describe("Search", () => {
     });
   });
 
+  /* test a full range of casing possibilities for one mismatch=0, with wildcards */
+  it("finds subsequence with ambiguity, uppercase query, wildcard", () => {
+    const query = "GCCCGNN"; // N character
+    const subject = "gattgcccgacggattc";
+    const mismatch = 0;
+
+    const results = search(query, mismatch, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 11,
+      direction: 1
+    });
+  });
+
+  it("finds subsequence with ambiguity, uppercase subject, wildcard", () => {
+    const query = "gcccgnn"; // N character
+    const subject = "GATTGCCCGACGGATTC";
+    const mismatch = 0;
+
+    const results = search(query, mismatch, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 11,
+      direction: 1
+    });
+  });
+
+  it("finds subsequence with ambiguity, uppercase both, wildcard", () => {
+    const query = "GCCCGNN"; // N character
+    const subject = "GATTGCCCGACGGATTC";
+    const mismatch = 0;
+
+    const results = search(query, mismatch, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 11,
+      direction: 1
+    });
+  });
+
   it("finds subsequence with mismatch", () => {
     const query = "gccggac"; // GC mismatch
     const subject = "gattgcccgacggattc";
@@ -58,6 +150,127 @@ describe("Search", () => {
     expect(results[0]).toMatchObject({
       start: 4,
       end: 11,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  /* test a full range of casing possibilities for one mismatch=1, no wildcards */
+  it("finds subsequence with mismatch", () => {
+    const query = "gccggac"; // GC mismatch
+    const subject = "gattgcccgacggattc";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 11,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  it("finds subsequence with mismatch", () => {
+    const query = "gccggac"; // GC mismatch
+    const subject = "gattgcccgacggattc";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 11,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  it("finds subsequence with mismatch", () => {
+    const query = "gccggac"; // GC mismatch
+    const subject = "gattgcccgacggattc";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 11,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  it("finds subsequence with mismatch, with wildcards", () => {
+    const query = "gcccgacy"; // y=ct, a mismatch
+    const subject = "gattgcccgacacattc";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 12,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  /* test a full range of casing possibilities for one mismatch=1, with wildcards */
+  it("finds subsequence with mismatch, with wildcards, uppercase query", () => {
+    const query = "GCCCGACY"; // y=ct, a mismatch
+    const subject = "gattgcccgacacattc";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 12,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  it("finds subsequence with mismatch, with wildcards, uppercase subject", () => {
+    const query = "gcccgacy"; // y=ct, a mismatch
+    const subject = "GATTGCCCGACACATTC";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 12,
+      direction: 1
+    });
+    expect(resultsNull.length).toEqual(0);
+  });
+
+  it("finds subsequence with mismatch, with wildcards, uppercase both", () => {
+    const query = "GCCCGACY"; // y=ct, a mismatch
+    const subject = "GATTGCCCGACACATTC";
+    const mismatch = 1;
+
+    const results = search(query, mismatch, subject);
+    const resultsNull = search(query, 0, subject);
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toMatchObject({
+      start: 4,
+      end: 12,
       direction: 1
     });
     expect(resultsNull.length).toEqual(0);


### PR DESCRIPTION
As mentioned in [Issue 102](https://github.com/Lattice-Automation/seqviz/issues/102), wildcard search was inadequately tested in general, case-insensitive search was inadequately tested in general, and mismatch search was manifestly broken for case insensitive matching.

This PR addresses all these issues and meets the coding format standards as I currently understand them. Thanks, and let me know how it looks!