### PR TITLE
Constrain keypresses to container

### DIFF
--- a/src/SeqViz/handlers/events.tsx
+++ b/src/SeqViz/handlers/events.tsx
@@ -24,14 +24,6 @@ const withEventRouter = WrappedComp =>
 
     clickedTwice = null;
 
-    componentDidMount = () => {
-      window.addEventListener("keydown", this.handleKeyPress);
-    };
-
-    componentWillUnmount = () => {
-      window.removeEventListener("keydown", this.handleKeyPress);
-    };
-
     /** set the event router reference on this class */
     setEventRouter = eventRouter => {
       this.eventRouter = eventRouter;
@@ -325,6 +317,8 @@ const withEventRouter = WrappedComp =>
           ref={ref => {
             this.eventRouter = ref;
           }}
+          // Need tabIndex for onKeyDown to work
+          tabIndex={-1}
         >
           <WrappedComp {...rest} mouseEvent={this.handleMouseEvent} />
         </div>


### PR DESCRIPTION
Add tab index and remove window event listener. We can rely on the existing onKeyDown binding. Fixes bug where selection changes when typing outside of container. Otherwise when the viewer is embedded within a larger application, user's keypresses may be incorrectly captured and affect the selection. For example, if there is a search bar and the user uses left and right arrow keys, this will undesirably affect the selection in the viewer, as demonstrated here:
![2021-12-02_16-36-13 (1)](https://user-images.githubusercontent.com/69694984/144526197-f17c8407-fb2b-4580-bfa4-ac896c80233c.gif)