### PR TITLE
Move to css-in-js approach

### DIFF
--- a/demo/lib/App.tsx
+++ b/demo/lib/App.tsx
@@ -33,7 +33,6 @@ interface AppState {
   customChildren: boolean;
   enzymes: any[];
   name: string;
-  primers: boolean;
   search: { query: string };
   searchResults: any;
   selection: any;
@@ -53,7 +52,6 @@ export default class App extends React.Component<any, AppState> {
     customChildren: true,
     enzymes: ["PstI", "EcoRI", "XbaI", "SpeI"],
     name: "",
-    primers: true,
     search: { query: "ttnnnaat" },
     searchResults: {},
     selection: {},
@@ -218,7 +216,9 @@ export default class App extends React.Component<any, AppState> {
                     key={`${this.state.viewer}${this.state.customChildren}`}
                     annotations={this.state.annotations}
                     enzymes={this.state.enzymes}
+                    highlights={[]}
                     name={this.state.name}
+                    onSelection={selection => this.setState({ selection })}
                     refs={{ circular: this.circularRef, linear: this.linearRef }}
                     search={this.state.search}
                     selection={this.state.selection}
@@ -228,7 +228,6 @@ export default class App extends React.Component<any, AppState> {
                     translations={this.state.translations}
                     viewer={this.state.viewer as "linear" | "circular"}
                     zoom={{ linear: this.state.zoom }}
-                    onSelection={selection => this.setState({ selection })}
                   >
                     {customChildren}
                   </SeqViz>

--- a/demo/lib/App.tsx
+++ b/demo/lib/App.tsx
@@ -216,7 +216,7 @@ export default class App extends React.Component<any, AppState> {
                     key={`${this.state.viewer}${this.state.customChildren}`}
                     annotations={this.state.annotations}
                     enzymes={this.state.enzymes}
-                    highlights={[]}
+                    highlights={[{ start: 0, end: 10 }]}
                     name={this.state.name}
                     onSelection={selection => this.setState({ selection })}
                     refs={{ circular: this.circularRef, linear: this.linearRef }}

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "browserslist": "^4.21.3",
-        "caniuse-lite": "^1.0.30001390",
         "history": "^4.10.1",
         "lodash": "^4.17.21",
         "next": "^12.3.1",
@@ -684,9 +683,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
       "funding": [
         {
           "type": "opencollective",
@@ -695,6 +694,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -2206,9 +2209,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ=="
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
     },
     "chrome-trace-event": {
       "version": "1.0.3",

--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "browserslist": "^4.21.3",
-    "caniuse-lite": "^1.0.30001390",
     "history": "^4.10.1",
     "lodash": "^4.17.21",
     "next": "^12.3.1",

--- a/demo/pages/_app.tsx
+++ b/demo/pages/_app.tsx
@@ -2,7 +2,6 @@ import Head from "next/head";
 import * as React from "react";
 import "semantic-ui-css/semantic.min.css";
 
-import "../../src/SeqViz.css";
 import "../styles/global.css";
 
 export default function App({ Component, pageProps }: any) {

--- a/demo/pages/index.tsx
+++ b/demo/pages/index.tsx
@@ -1,8 +1,5 @@
-import dynamic from "next/dynamic";
 import * as React from "react";
 
-const App = dynamic(() => import("../lib/App"), {
-  ssr: false,
-});
+import App from "../lib/App";
 
 export default () => <App />;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,4 @@
 module.exports = {
-  moduleNameMapper: {
-    "\\.(css|less|scss|sss|styl)$": "<rootDir>/node_modules/jest-css-modules",
-  },
   preset: "ts-jest",
   roots: ["<rootDir>/src"],
   setupFiles: ["<rootDir>/src/jest.js"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "react-resize-detector": "^7.1.2",
-        "seqparse": "^0.2.0"
+        "seqparse": "^0.2.0",
+        "styled-components": "^5.3.8"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -79,7 +80,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -130,11 +130,34 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
       "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -162,7 +185,6 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -171,7 +193,6 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -184,7 +205,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -198,7 +218,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -210,7 +229,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -224,7 +242,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -236,7 +253,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -379,7 +395,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -391,7 +406,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -402,10 +416,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
-      "dev": true,
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -414,7 +427,6 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -521,7 +533,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -535,7 +546,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -547,7 +557,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -561,7 +570,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -569,14 +577,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -585,7 +591,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -594,7 +599,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -606,7 +610,6 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
       "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -792,7 +795,6 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
       "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.10",
@@ -806,7 +808,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
       "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -818,7 +819,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -832,7 +832,6 @@
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
       "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.17.3",
@@ -853,7 +852,6 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -876,6 +874,29 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -2890,6 +2911,26 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
+      }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -3210,6 +3251,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3581,6 +3630,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-loader": {
       "version": "6.7.3",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
@@ -3636,6 +3693,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-what": {
@@ -3729,7 +3796,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5227,7 +5293,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5353,6 +5418,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -7363,7 +7441,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -7832,8 +7909,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -8367,7 +8443,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -8584,8 +8659,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -8847,8 +8921,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-resize-detector": {
       "version": "7.1.2",
@@ -9378,6 +9451,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9449,7 +9527,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9843,6 +9920,54 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/styled-components": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.8.tgz",
+      "integrity": "sha512-6jQrlvaJQ16uWVVO0rBfApaTPItkqaG32l3746enNZzpMDxMvzmHzj8rHUg39bvVtom0Y8o8ZzWuchEXKGjVsg==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/styled-components/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10088,7 +10213,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11160,7 +11284,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -11198,11 +11321,30 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
       "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+      "requires": {
+        "@babel/types": "^7.18.6"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.21.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+          "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+          "requires": {
+            "@babel/helper-string-parser": "^7.19.4",
+            "@babel/helper-validator-identifier": "^7.19.1",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-compilation-targets": {
@@ -11220,14 +11362,12 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-      "dev": true
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
     },
     "@babel/helper-function-name": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -11237,7 +11377,6 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11250,7 +11389,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
@@ -11259,7 +11397,6 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11272,7 +11409,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
@@ -11281,7 +11417,6 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11397,7 +11532,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
@@ -11406,7 +11540,6 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11416,16 +11549,14 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
-      "dev": true
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -11507,7 +11638,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -11518,7 +11648,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -11527,7 +11656,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -11538,7 +11666,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -11546,26 +11673,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -11575,8 +11698,7 @@
     "@babel/parser": {
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-      "dev": true
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -11708,7 +11830,6 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
       "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.10",
@@ -11718,14 +11839,12 @@
         "@babel/parser": {
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
-          "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
-          "dev": true
+          "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ=="
         },
         "@babel/types": {
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
-          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11738,7 +11857,6 @@
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
       "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.17.3",
@@ -11756,7 +11874,6 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -11773,6 +11890,29 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -13383,6 +13523,23 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+    },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -13619,6 +13776,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-lite": {
       "version": "1.0.30001418",
@@ -13901,6 +14063,11 @@
         "which": "^2.0.1"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+    },
     "css-loader": {
       "version": "6.7.3",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
@@ -13939,6 +14106,16 @@
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
+      }
+    },
+    "css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-what": {
@@ -14015,7 +14192,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -15126,8 +15302,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "11.1.0",
@@ -15217,6 +15392,21 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -16714,8 +16904,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -17071,8 +17260,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -17476,8 +17664,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pirates": {
       "version": "4.0.5",
@@ -17615,8 +17802,7 @@
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -17815,8 +18001,7 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-resize-detector": {
       "version": "7.1.2",
@@ -18232,6 +18417,11 @@
         "kind-of": "^6.0.2"
       }
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -18290,8 +18480,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
     },
     "source-map-js": {
       "version": "1.0.2",
@@ -18591,6 +18780,38 @@
       "dev": true,
       "requires": {}
     },
+    "styled-components": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.8.tgz",
+      "integrity": "sha512-6jQrlvaJQ16uWVVO0rBfApaTPItkqaG32l3746enNZzpMDxMvzmHzj8rHUg39bvVtom0Y8o8ZzWuchEXKGjVsg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -18766,8 +18987,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "react-resize-detector": "^7.1.2",
-        "seqparse": "^0.2.0",
-        "styled-components": "^5.3.8"
+        "seqparse": "^0.2.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -80,6 +79,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -130,34 +130,11 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
       "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.19.4",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -185,6 +162,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -193,6 +171,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -205,6 +184,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -218,6 +198,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -229,6 +210,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -242,6 +224,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -253,6 +236,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -395,6 +379,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -406,6 +391,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -419,6 +405,7 @@
       "version": "7.19.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
       "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -427,6 +414,7 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -533,6 +521,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -546,6 +535,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -557,6 +547,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -570,6 +561,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -577,12 +569,14 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -591,6 +585,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -599,6 +594,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -610,6 +606,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
       "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -795,6 +792,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
       "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.10",
@@ -808,6 +806,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
       "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -819,6 +818,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
       "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -832,6 +832,7 @@
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
       "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.17.3",
@@ -852,6 +853,7 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -898,29 +900,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -2964,26 +2943,6 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
-      }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
-    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -3304,14 +3263,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3708,14 +3659,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/css-loader": {
       "version": "6.7.3",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
@@ -3771,16 +3714,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-what": {
@@ -3874,6 +3807,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5381,6 +5315,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5506,19 +5441,6 @@
       "bin": {
         "he": "bin/he"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -7529,6 +7451,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -7997,7 +7920,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -8531,6 +8455,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -8758,7 +8683,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9020,7 +8946,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-resize-detector": {
       "version": "7.1.2",
@@ -9550,11 +9477,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9626,6 +9548,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10019,54 +9942,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/styled-components": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.8.tgz",
-      "integrity": "sha512-6jQrlvaJQ16uWVVO0rBfApaTPItkqaG32l3746enNZzpMDxMvzmHzj8rHUg39bvVtom0Y8o8ZzWuchEXKGjVsg==",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10312,6 +10187,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11445,6 +11321,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -11482,30 +11359,11 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
       "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
-      }
-    },
-    "@babel/helper-annotate-as-pure": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-      "requires": {
-        "@babel/types": "^7.18.6"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.21.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-          "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
-          "requires": {
-            "@babel/helper-string-parser": "^7.19.4",
-            "@babel/helper-validator-identifier": "^7.19.1",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-compilation-targets": {
@@ -11523,12 +11381,14 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-function-name": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -11538,6 +11398,7 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11550,6 +11411,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
@@ -11558,6 +11420,7 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11570,6 +11433,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
@@ -11578,6 +11442,7 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11693,6 +11558,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
@@ -11701,6 +11567,7 @@
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -11712,12 +11579,14 @@
     "@babel/helper-string-parser": {
       "version": "7.19.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -11799,6 +11668,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -11809,6 +11679,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -11817,6 +11688,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -11827,6 +11699,7 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -11834,22 +11707,26 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -11859,7 +11736,8 @@
     "@babel/parser": {
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -11991,6 +11869,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
       "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.10",
@@ -12000,12 +11879,14 @@
         "@babel/parser": {
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
-          "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ=="
+          "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
+          "dev": true
         },
         "@babel/types": {
           "version": "7.19.3",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
           "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.18.10",
             "@babel/helper-validator-identifier": "^7.19.1",
@@ -12018,6 +11899,7 @@
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
       "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.17.3",
@@ -12035,6 +11917,7 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -12074,29 +11957,6 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
-    },
-    "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
-      "requires": {
-        "@emotion/memoize": "^0.8.0"
-      }
-    },
-    "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
-    },
-    "@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-    },
-    "@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -13736,23 +13596,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
-      }
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
-    },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -13989,11 +13832,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
-    },
-    "camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-lite": {
       "version": "1.0.30001418",
@@ -14289,11 +14127,6 @@
         "which": "^2.0.1"
       }
     },
-    "css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
-    },
     "css-loader": {
       "version": "6.7.3",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
@@ -14332,16 +14165,6 @@
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
-      }
-    },
-    "css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "requires": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-what": {
@@ -14418,6 +14241,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -15535,7 +15359,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "globby": {
       "version": "11.1.0",
@@ -15625,21 +15450,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -17137,7 +16947,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -17493,7 +17304,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -17897,7 +17709,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pirates": {
       "version": "4.0.5",
@@ -18036,7 +17849,8 @@
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -18235,7 +18049,8 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "react-resize-detector": {
       "version": "7.1.2",
@@ -18651,11 +18466,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -18714,7 +18524,8 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.2",
@@ -19014,38 +18825,6 @@
       "dev": true,
       "requires": {}
     },
-    "styled-components": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.8.tgz",
-      "integrity": "sha512-6jQrlvaJQ16uWVVO0rBfApaTPItkqaG32l3746enNZzpMDxMvzmHzj8rHUg39bvVtom0Y8o8ZzWuchEXKGjVsg==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -19221,7 +19000,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "react-resize-detector": "^7.1.2",
-        "seqparse": "^0.2.0"
+        "seqparse": "^0.2.1",
+        "webfontloader": "^1.6.28"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -22,7 +23,6 @@
         "@types/xml2js": "^0.4.9",
         "@typescript-eslint/eslint-plugin": "^5.10.1",
         "@typescript-eslint/parser": "^5.10.1",
-        "css-loader": "^6.7.3",
         "eslint": "^8.8.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -31,17 +31,13 @@
         "eslint-plugin-typescript-sort-keys": "^2.1.0",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^28.0.0",
-        "jest-css-modules": "^2.1.0",
         "jest-environment-jsdom": "^28.1.3",
-        "mini-css-extract-plugin": "^2.6.1",
         "path-browserify": "^1.0.1",
-        "postcss-loader": "^7.0.1",
         "prettier": "^2.5.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "source-map-loader": "^1.1.3",
         "stream-browserify": "^3.0.0",
-        "style-loader": "^3.3.1",
         "timers-browserify": "^2.0.12",
         "ts-jest": "^28.0.0",
         "ts-loader": "^8.3.0",
@@ -873,6 +869,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -886,6 +883,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1727,6 +1725,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node12": {
@@ -1734,6 +1733,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node14": {
@@ -1741,6 +1741,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node16": {
@@ -1748,6 +1749,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/aria-query": {
@@ -2800,6 +2802,7 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/argparse": {
@@ -3266,9 +3269,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001418",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
-      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
       "dev": true,
       "funding": [
         {
@@ -3278,6 +3281,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -3604,45 +3611,12 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
-    "node_modules/cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
-      "dev": true,
-      "dependencies": {
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      }
-    },
-    "node_modules/cosmiconfig-typescript-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
-      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "cosmiconfig": ">=7",
-        "ts-node": ">=10",
-        "typescript": ">=3"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/cross-spawn": {
@@ -3657,47 +3631,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-loader": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
-      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.19",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/css-select": {
@@ -3733,18 +3666,6 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -3932,6 +3853,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
@@ -5358,12 +5280,6 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
-    "node_modules/harmony-reflect": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "dev": true
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5686,30 +5602,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "dev": true,
-      "dependencies": {
-        "harmony-reflect": "^1.4.6"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -6503,15 +6395,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "node_modules/jest-css-modules": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jest-css-modules/-/jest-css-modules-2.1.0.tgz",
-      "integrity": "sha512-my3Scnt6l2tOll/eGwNZeh1KLAFkNzdl4MyZRdpl46GO6/93JcKKdTjNqK6Nokg8A8rT84MFLOpY1pzqKBEqMw==",
-      "dev": true,
-      "dependencies": {
-        "identity-obj-proxy": "3.0.0"
-      }
     },
     "node_modules/jest-diff": {
       "version": "28.1.3",
@@ -7526,15 +7409,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7827,78 +7701,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
-      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
-      "dev": true,
-      "dependencies": {
-        "schema-utils": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7934,18 +7736,6 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -8535,156 +8325,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-loader": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.2.4.tgz",
-      "integrity": "sha512-F88rpxxNspo5hatIc+orYwZDtHFaVFOSIVAx+fBfJC1GmhWbVmPWtmg2gXKE1OxJbneOSGn8PWdIwsZFcruS+w==",
-      "dev": true,
-      "dependencies": {
-        "cosmiconfig": "^8.1.3",
-        "cosmiconfig-typescript-loader": "^4.3.0",
-        "klona": "^2.0.6",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "postcss": "^7.0.0 || ^8.0.1",
-        "ts-node": ">=10",
-        "typescript": ">=4",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ts-node": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "dev": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9337,9 +8977,9 @@
       "dev": true
     },
     "node_modules/seqparse": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/seqparse/-/seqparse-0.2.0.tgz",
-      "integrity": "sha512-0MLjTliyrkNxf5Y0lBlAT0ZIoyKfENg0wqVb2jFFdwBcRUlyZQaI7UrE4ExeXfjbZ2QCqiXK3ZZYdd47yJl2RA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/seqparse/-/seqparse-0.2.1.tgz",
+      "integrity": "sha512-IFF+K4ggicnsuOGhVtXBw7qwkJZHqPYiMSVjMQIxmjTLcEGCE/BipQ91ZsKvZ36GSSutwGcDA3WxPaiLeGChHQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "fast-xml-parser": "^4.0.13",
@@ -9548,15 +9188,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9925,22 +9556,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
-    },
-    "node_modules/style-loader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -10368,6 +9983,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -10412,6 +10028,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -10616,6 +10233,7 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/v8-to-istanbul": {
@@ -10692,6 +10310,11 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/webfontloader": {
+      "version": "1.6.28",
+      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+      "integrity": "sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -11282,6 +10905,7 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -11934,6 +11558,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -11944,6 +11569,7 @@
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
           "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
           "dev": true,
+          "optional": true,
           "peer": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
@@ -12604,6 +12230,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node12": {
@@ -12611,6 +12238,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node14": {
@@ -12618,6 +12246,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node16": {
@@ -12625,6 +12254,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@types/aria-query": {
@@ -13487,6 +13117,7 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "argparse": {
@@ -13834,9 +13465,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001418",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
-      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
       "dev": true
     },
     "chalk": {
@@ -14090,30 +13721,12 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
-    "cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
-      "dev": true,
-      "requires": {
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
-      }
-    },
-    "cosmiconfig-typescript-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
-      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
-      "dev": true,
-      "requires": {}
-    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "cross-spawn": {
@@ -14125,33 +13738,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      }
-    },
-    "css-loader": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
-      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.19",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.8"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "css-select": {
@@ -14177,12 +13763,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true
-    },
-    "cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssom": {
@@ -14330,6 +13910,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "diff-sequences": {
@@ -15394,12 +14975,6 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
-    "harmony-reflect": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "dev": true
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -15641,22 +15216,6 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
-    "icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
-    },
-    "identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "dev": true,
-      "requires": {
-        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {
@@ -16203,15 +15762,6 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
-      }
-    },
-    "jest-css-modules": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jest-css-modules/-/jest-css-modules-2.1.0.tgz",
-      "integrity": "sha512-my3Scnt6l2tOll/eGwNZeh1KLAFkNzdl4MyZRdpl46GO6/93JcKKdTjNqK6Nokg8A8rT84MFLOpY1pzqKBEqMw==",
-      "dev": true,
-      "requires": {
-        "identity-obj-proxy": "3.0.0"
       }
     },
     "jest-diff": {
@@ -17002,12 +16552,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -17236,56 +16780,6 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
-    "mini-css-extract-plugin": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
-      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
-      "dev": true,
-      "requires": {
-        "schema-utils": "^4.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "ajv": "^8.8.0",
-            "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.0.0"
-          }
-        }
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -17316,12 +16810,6 @@
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       }
-    },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17765,92 +17253,6 @@
           }
         }
       }
-    },
-    "postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "postcss-loader": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.2.4.tgz",
-      "integrity": "sha512-F88rpxxNspo5hatIc+orYwZDtHFaVFOSIVAx+fBfJC1GmhWbVmPWtmg2gXKE1OxJbneOSGn8PWdIwsZFcruS+w==",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^8.1.3",
-        "cosmiconfig-typescript-loader": "^4.3.0",
-        "klona": "^2.0.6",
-        "semver": "^7.3.8"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      }
-    },
-    "postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.4"
-      }
-    },
-    "postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.0.0"
-      }
-    },
-    "postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -18345,9 +17747,9 @@
       }
     },
     "seqparse": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/seqparse/-/seqparse-0.2.0.tgz",
-      "integrity": "sha512-0MLjTliyrkNxf5Y0lBlAT0ZIoyKfENg0wqVb2jFFdwBcRUlyZQaI7UrE4ExeXfjbZ2QCqiXK3ZZYdd47yJl2RA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/seqparse/-/seqparse-0.2.1.tgz",
+      "integrity": "sha512-IFF+K4ggicnsuOGhVtXBw7qwkJZHqPYiMSVjMQIxmjTLcEGCE/BipQ91ZsKvZ36GSSutwGcDA3WxPaiLeGChHQ==",
       "requires": {
         "buffer": "^6.0.3",
         "fast-xml-parser": "^4.0.13",
@@ -18525,12 +17927,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true
-    },
-    "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-loader": {
@@ -18817,13 +18213,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
-    },
-    "style-loader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true,
-      "requires": {}
     },
     "supports-color": {
       "version": "7.2.0",
@@ -19116,6 +18505,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -19138,6 +18528,7 @@
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true,
+          "optional": true,
           "peer": true
         }
       }
@@ -19284,6 +18675,7 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "v8-to-istanbul": {
@@ -19348,6 +18740,11 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "webfontloader": {
+      "version": "1.6.28",
+      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+      "integrity": "sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ=="
     },
     "webidl-conversions": {
       "version": "7.0.0",
@@ -19758,6 +19155,7 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   ],
   "dependencies": {
     "react-resize-detector": "^7.1.2",
-    "seqparse": "^0.2.0"
+    "seqparse": "^0.2.1",
+    "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
@@ -60,7 +61,6 @@
     "@types/xml2js": "^0.4.9",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
-    "css-loader": "^6.7.3",
     "eslint": "^8.8.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -69,17 +69,13 @@
     "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^28.0.0",
-    "jest-css-modules": "^2.1.0",
     "jest-environment-jsdom": "^28.1.3",
-    "mini-css-extract-plugin": "^2.6.1",
     "path-browserify": "^1.0.1",
-    "postcss-loader": "^7.0.1",
     "prettier": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "source-map-loader": "^1.1.3",
     "stream-browserify": "^3.0.0",
-    "style-loader": "^3.3.1",
     "timers-browserify": "^2.0.12",
     "ts-jest": "^28.0.0",
     "ts-loader": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   ],
   "dependencies": {
     "react-resize-detector": "^7.1.2",
-    "seqparse": "^0.2.0",
-    "styled-components": "^5.3.8"
+    "seqparse": "^0.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   ],
   "dependencies": {
     "react-resize-detector": "^7.1.2",
-    "seqparse": "^0.2.0"
+    "seqparse": "^0.2.0",
+    "styled-components": "^5.3.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/Circular/Annotations.tsx
+++ b/src/Circular/Annotations.tsx
@@ -4,7 +4,7 @@ import { InputRefFunc } from "../SelectionHandler";
 import CentralIndexContext from "../centralIndexContext";
 import { COLOR_BORDER_MAP, darkerColor } from "../colors";
 import { Annotation } from "../elements";
-import { svgText } from "../style";
+import { annotation, annotationLabel, svgText } from "../style";
 import { GenArcFunc } from "./Circular";
 
 interface AnnotationsProps {
@@ -184,6 +184,7 @@ const SingleAnnotation = (props: SingleAnnotationProps) => {
         }}
         onMouseOut={() => hoverAnnotation(a.id, "0.7")}
         onMouseOver={() => hoverAnnotation(a.id, "1.0")}
+        style={annotation}
       />
       {inlinedAnnotations.includes(a.id) && (
         <text
@@ -208,6 +209,7 @@ const SingleAnnotation = (props: SingleAnnotationProps) => {
             startOffset={bottomHalf ? "25%" : "75%"}
             textAnchor="middle"
             xlinkHref={`#${circAnnID}`}
+            style={annotationLabel}
           >
             {a.name}
           </textPath>

--- a/src/Circular/Annotations.tsx
+++ b/src/Circular/Annotations.tsx
@@ -4,6 +4,7 @@ import { InputRefFunc } from "../SelectionHandler";
 import CentralIndexContext from "../centralIndexContext";
 import { COLOR_BORDER_MAP, darkerColor } from "../colors";
 import { Annotation } from "../elements";
+import { svgText } from "../style";
 import { GenArcFunc } from "./Circular";
 
 interface AnnotationsProps {
@@ -196,6 +197,7 @@ const SingleAnnotation = (props: SingleAnnotationProps) => {
           }}
           onMouseOut={() => hoverAnnotation(a.id, "0.7")}
           onMouseOver={() => hoverAnnotation(a.id, "1.0")}
+          style={svgText}
         >
           <textPath
             className="la-vz-annotation-label"

--- a/src/Circular/Annotations.tsx
+++ b/src/Circular/Annotations.tsx
@@ -50,7 +50,7 @@ export class Annotations extends React.PureComponent<AnnotationsProps> {
       <CentralIndexContext.Consumer>
         {({ circular }) => (
           <g className="la-vz-circular-annotations">
-            {annotations.reduce((acc: any[], anns: Annotation[], i) => {
+            {annotations.reduce((acc: React.ReactNode[], anns: Annotation[], i) => {
               if (i) {
                 // increment the annRow radii on every loop after first
                 currBRadius -= lineHeight + 3;
@@ -87,7 +87,7 @@ export class Annotations extends React.PureComponent<AnnotationsProps> {
 
 interface SingleAnnotationProps {
   annotation: Annotation;
-  calcBorderColor: (c: any) => any;
+  calcBorderColor: (c: string) => string;
   centralIndex: number;
   currBRadius: number;
   currTRadius: number;
@@ -176,6 +176,7 @@ const SingleAnnotation = (props: SingleAnnotationProps) => {
         fill={a.color}
         id={a.id}
         stroke={a.color ? COLOR_BORDER_MAP[a.color] || calcBorderColor(a.color) : "gray"}
+        style={annotation}
         onBlur={() => {
           // do nothing
         }}
@@ -184,7 +185,6 @@ const SingleAnnotation = (props: SingleAnnotationProps) => {
         }}
         onMouseOut={() => hoverAnnotation(a.id, "0.7")}
         onMouseOver={() => hoverAnnotation(a.id, "1.0")}
-        style={annotation}
       />
       {inlinedAnnotations.includes(a.id) && (
         <text
@@ -207,9 +207,9 @@ const SingleAnnotation = (props: SingleAnnotationProps) => {
             fontSize={12}
             id={a.id}
             startOffset={bottomHalf ? "25%" : "75%"}
+            style={annotationLabel}
             textAnchor="middle"
             xlinkHref={`#${circAnnID}`}
-            style={annotationLabel}
           >
             {a.name}
           </textPath>

--- a/src/Circular/Circular.tsx
+++ b/src/Circular/Circular.tsx
@@ -341,12 +341,12 @@ export default class Circular extends React.Component<CircularProps, CircularSta
         height={size.height}
         id={plasmidId}
         overflow="visible"
+        style={viewerCircular}
         width={size.width >= 0 ? size.width : 0}
         onMouseDown={handleMouseEvent}
         onMouseMove={handleMouseEvent}
         onMouseUp={handleMouseEvent}
         onWheel={this.handleScrollEvent}
-        style={viewerCircular}
       >
         <g className="la-vz-circular-root" transform={`translate(0, ${yDiff})`}>
           <Selection {...props} seq={seq} totalRows={totalRows} />
@@ -396,7 +396,7 @@ export const Arc = (props: {
   start: number;
   style: React.CSSProperties;
 }) => {
-  const { color, direction, genArc, getRotation, inputRef, className, lineHeight, radius, seqLength, start, style } =
+  const { className, color, direction, genArc, getRotation, inputRef, lineHeight, radius, seqLength, start, style } =
     props;
 
   let { end } = props;
@@ -419,7 +419,6 @@ export const Arc = (props: {
   return (
     <path
       key={id}
-      className={className}
       ref={inputRef(id, {
         end: end,
         ref: id,
@@ -427,6 +426,7 @@ export const Arc = (props: {
         type: "FIND",
         viewer: "CIRCULAR",
       })}
+      className={className}
       cursor="pointer"
       d={findPath}
       fill={color}

--- a/src/Circular/Circular.tsx
+++ b/src/Circular/Circular.tsx
@@ -6,6 +6,7 @@ import CentralIndexContext from "../centralIndexContext";
 import { Annotation, Coor, CutSite, Highlight, Range, Size } from "../elements";
 import { stackElements } from "../elementsToRows";
 import { isEqual } from "../isEqual";
+import { viewerCircular } from "../style";
 import { Annotations } from "./Annotations";
 import { CutSites } from "./CutSites";
 import { Find } from "./Find";
@@ -345,6 +346,7 @@ export default class Circular extends React.Component<CircularProps, CircularSta
         onMouseMove={handleMouseEvent}
         onMouseUp={handleMouseEvent}
         onWheel={this.handleScrollEvent}
+        style={viewerCircular}
       >
         <g className="la-vz-circular-root" transform={`translate(0, ${yDiff})`}>
           <Selection {...props} seq={seq} totalRows={totalRows} />
@@ -381,6 +383,7 @@ export default class Circular extends React.Component<CircularProps, CircularSta
  * Create an SVG arc around a single element in the Circular Viewer.
  */
 export const Arc = (props: {
+  className: string;
   color?: string;
   direction: -1 | 1;
   end: number;
@@ -393,7 +396,8 @@ export const Arc = (props: {
   start: number;
   style: React.CSSProperties;
 }) => {
-  const { color, direction, genArc, getRotation, inputRef, lineHeight, radius, seqLength, start, style } = props;
+  const { color, direction, genArc, getRotation, inputRef, className, lineHeight, radius, seqLength, start, style } =
+    props;
 
   let { end } = props;
   // crosses the zero index
@@ -415,6 +419,7 @@ export const Arc = (props: {
   return (
     <path
       key={id}
+      className={className}
       ref={inputRef(id, {
         end: end,
         ref: id,

--- a/src/Circular/Circular.tsx
+++ b/src/Circular/Circular.tsx
@@ -344,6 +344,7 @@ export default class Circular extends React.Component<CircularProps, CircularSta
         onMouseMove={handleMouseEvent}
         onMouseUp={handleMouseEvent}
         onWheel={this.handleScrollEvent}
+        overflow="visible"
       >
         <g className="la-vz-circular-root" transform={`translate(0, ${yDiff})`}>
           <Selection {...props} seq={seq} totalRows={totalRows} />
@@ -380,7 +381,6 @@ export default class Circular extends React.Component<CircularProps, CircularSta
  * Create an SVG arc around a single element in the Circular Viewer.
  */
 export const Arc = (props: {
-  className: string;
   color?: string;
   direction: -1 | 1;
   end: number;
@@ -391,8 +391,9 @@ export const Arc = (props: {
   radius: number;
   seqLength: number;
   start: number;
+  style: React.CSSProperties;
 }) => {
-  const { className, color, direction, genArc, getRotation, inputRef, lineHeight, radius, seqLength, start } = props;
+  const { color, direction, genArc, getRotation, inputRef, lineHeight, radius, seqLength, start } = props;
 
   let { end } = props;
   // crosses the zero index
@@ -409,7 +410,7 @@ export const Arc = (props: {
     sweepFWD: true,
   });
 
-  const id = `${className}-circular-${start}-${end}-${direction}`;
+  const id = `circular-${start}-${end}-${direction}`;
 
   return (
     <path
@@ -421,7 +422,6 @@ export const Arc = (props: {
         type: "FIND",
         viewer: "CIRCULAR",
       })}
-      className={className}
       cursor="pointer"
       d={findPath}
       fill={color}

--- a/src/Circular/CutSites.tsx
+++ b/src/Circular/CutSites.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { Coor, CutSite } from "../elements";
-import { cutSite as cutSiteStyle } from "../style";
+import { cutSiteHighlight, cutSite as cutSiteStyle } from "../style";
 import { GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 interface CutSitesProps {
@@ -97,7 +97,7 @@ const SingleCutSite = (props: {
           outerRadius: topR,
           sweepFWD: true,
         })}
-        style={cutSite.enzyme.color ? { ...cutSiteStyle, fill: cutSite.enzyme.color } : cutSiteStyle}
+        style={cutSite.enzyme.color ? { ...cutSiteHighlight, fill: cutSite.enzyme.color } : cutSiteHighlight}
       />
 
       {/* a line showing the start of the cut-site */}

--- a/src/Circular/CutSites.tsx
+++ b/src/Circular/CutSites.tsx
@@ -88,6 +88,7 @@ const SingleCutSite = (props: {
           type: "ENZYME",
           viewer: "CIRCULAR",
         })}
+        className="la-vz-cut-site"
         cursor="pointer"
         d={genArc({
           innerRadius: botR,
@@ -100,7 +101,7 @@ const SingleCutSite = (props: {
       />
 
       {/* a line showing the start of the cut-site */}
-      <path d={calculateLinePath(fcut - start, topR, midR)} style={cutSiteStyle} />
+      <path className="la-vz-cut-site" d={calculateLinePath(fcut - start, topR, midR)} style={cutSiteStyle} />
 
       {/* a connector line for the cut-site */}
       <path
@@ -117,7 +118,7 @@ const SingleCutSite = (props: {
       />
 
       {/* a line showing the end of the cut-site */}
-      <path d={calculateLinePath(rcut - start, midR, botR)} style={cutSiteStyle} />
+      <path className="la-vz-cut-site" d={calculateLinePath(rcut - start, midR, botR)} style={cutSiteStyle} />
     </g>
   );
 };

--- a/src/Circular/CutSites.tsx
+++ b/src/Circular/CutSites.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { Coor, CutSite } from "../elements";
+import { cutSite as cutSiteStyle } from "../style";
 import { GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 interface CutSitesProps {
@@ -87,7 +88,6 @@ const SingleCutSite = (props: {
           type: "ENZYME",
           viewer: "CIRCULAR",
         })}
-        className="la-vz-cut-site"
         cursor="pointer"
         d={genArc({
           innerRadius: botR,
@@ -96,11 +96,11 @@ const SingleCutSite = (props: {
           outerRadius: topR,
           sweepFWD: true,
         })}
-        style={cutSite.enzyme.color ? { fill: cutSite.enzyme.color } : {}}
+        style={cutSite.enzyme.color ? { ...cutSiteStyle, fill: cutSite.enzyme.color } : cutSiteStyle}
       />
 
       {/* a line showing the start of the cut-site */}
-      <path className="la-vz-cut-site" d={calculateLinePath(fcut - start, topR, midR)} />
+      <path d={calculateLinePath(fcut - start, topR, midR)} style={cutSiteStyle} />
 
       {/* a connector line for the cut-site */}
       <path
@@ -113,10 +113,11 @@ const SingleCutSite = (props: {
           outerRadius: midR,
           sweepFWD: true,
         })}
+        style={cutSiteStyle}
       />
 
       {/* a line showing the end of the cut-site */}
-      <path className="la-vz-cut-site" d={calculateLinePath(rcut - start, midR, botR)} />
+      <path style={cutSiteStyle} d={calculateLinePath(rcut - start, midR, botR)} />
     </g>
   );
 };

--- a/src/Circular/Find.tsx
+++ b/src/Circular/Find.tsx
@@ -24,6 +24,7 @@ export const Find = (props: {
         search.map(s => (
           <Arc
             key={JSON.stringify(s)}
+            className="la-vz-search" // isn't necessary except it used to be set, am afraid some customer is using it
             direction={s.direction || 1}
             end={s.end}
             genArc={genArc}
@@ -40,6 +41,7 @@ export const Find = (props: {
       {highlights.map(({ color, end, start }) => (
         <Arc
           key={`la-vz-highlight-${start}-${end}`}
+          className="la-vz-search"
           color={color}
           direction={1}
           end={end}

--- a/src/Circular/Find.tsx
+++ b/src/Circular/Find.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { HighlightProp, Range } from "../elements";
+import { search } from "../style";
 import { Arc, GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 export const Find = (props: {
@@ -23,7 +24,6 @@ export const Find = (props: {
         search.map(s => (
           <Arc
             key={JSON.stringify(s)}
-            className="la-vz-search"
             direction={s.direction || 1}
             end={s.end}
             genArc={genArc}
@@ -33,13 +33,13 @@ export const Find = (props: {
             radius={radius}
             seqLength={seqLength}
             start={s.start}
+            style={search}
           />
         ))}
 
       {highlights.map(({ color, end, start }) => (
         <Arc
           key={`la-vz-highlight-${start}-${end}`}
-          className="la-vz-highlight"
           color={color}
           direction={1}
           end={end}
@@ -50,6 +50,7 @@ export const Find = (props: {
           radius={radius}
           seqLength={seqLength}
           start={start}
+          style={search}
         />
       ))}
     </g>

--- a/src/Circular/Index.tsx
+++ b/src/Circular/Index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import CentralIndexContext from "../centralIndexContext";
 import { Coor, Size } from "../elements";
+import { indexLine, indexTick, indexTickLabel, svgText } from "../style";
 import { GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 interface IndexProps {
@@ -98,6 +99,7 @@ export class Index extends React.PureComponent<IndexProps> {
           {...findCoor(0, radius + 2 * lineHeight)}
           dominantBaseline="middle"
           transform={getRotation(i)}
+          style={svgText}
         >
           {seqForCircular.charAt(i)}
         </text>,
@@ -106,6 +108,7 @@ export class Index extends React.PureComponent<IndexProps> {
           {...findCoor(0, radius + lineHeight)}
           dominantBaseline="middle"
           transform={getRotation(i)}
+          style={svgText}
         >
           {compSeqForCircular.charAt(i)}
         </text>
@@ -192,7 +195,7 @@ export class Index extends React.PureComponent<IndexProps> {
     return (
       <g>
         {/* A label showing the name of the plasmid */}
-        <text fontSize={20} fontWeight={500} textAnchor="middle">
+        <text fontSize={20} fontWeight={500} textAnchor="middle" style={svgText}>
           {nameSpans.map((n, i) => (
             <tspan key={n} x={nameCoor.x} y={nameCoor.y + i * 25}>
               {n}
@@ -201,7 +204,7 @@ export class Index extends React.PureComponent<IndexProps> {
         </text>
 
         {/* A label for the length of the plasmid */}
-        <text x={nameCoor.x} y={nameCoor.y + 14 + 25 * (nameSpans.length - 1)} {...subtitleStyle}>
+        <text x={nameCoor.x} y={nameCoor.y + 14 + 25 * (nameSpans.length - 1)} {...subtitleStyle} style={svgText}>
           {`${seqLength} bp`}
         </text>
 
@@ -214,13 +217,14 @@ export class Index extends React.PureComponent<IndexProps> {
             <path
               className="la-vz-index-tick"
               d={`M ${tickCoorStart.x} ${tickCoorStart.y} L ${tickCoorEnd.x} ${tickCoorEnd.y}`}
+              style={indexTick}
             />
             <text
               className="la-vz-index-tick-label"
-              fontSize={12}
               textAnchor="middle"
               x={tickCoorEnd.x}
               y={tickCoorEnd.y + lineHeight}
+              style={indexTickLabel}
             >
               {t}
             </text>
@@ -229,8 +233,18 @@ export class Index extends React.PureComponent<IndexProps> {
 
         {/* The two arcs that make the plasmid's circle */}
         <g>
-          <path className="la-vz-index-line" d={indexCurve} transform={getRotation(seqLength * 0.75)} />
-          <path className="la-vz-index-line" d={indexCurve} transform={getRotation(seqLength * 0.25)} />
+          <path
+            className="la-vz-index-line"
+            d={indexCurve}
+            transform={getRotation(seqLength * 0.75)}
+            style={indexLine}
+          />
+          <path
+            className="la-vz-index-line"
+            d={indexCurve}
+            transform={getRotation(seqLength * 0.25)}
+            style={indexLine}
+          />
         </g>
       </g>
     );

--- a/src/Circular/Labels.tsx
+++ b/src/Circular/Labels.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { CHAR_WIDTH } from "../SeqViewerContainer";
 import { Coor, Size } from "../elements";
-import { svgText } from "../style";
+import { circularLabel, circularLabelLine, svgText } from "../style";
 import { GenArcFunc, ILabel, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 import { WrappedGroupLabel } from "./WrappedGroupLabel";
 
@@ -295,9 +295,17 @@ export class Labels extends React.Component<LabelsProps, LabelsState> {
           const fC = g.forkCoor || g.textCoor;
           const labelLines = (
             <>
-              <path className="la-vz-label-line" d={`M${g.lineCoor.x} ${g.lineCoor.y} L${fC.x} ${fC.y}`} />
+              <path
+                className="la-vz-label-line"
+                d={`M${g.lineCoor.x} ${g.lineCoor.y} L${fC.x} ${fC.y}`}
+                style={circularLabelLine}
+              />
               {g.forkCoor && (
-                <path className="la-vz-label-line" d={`M${fC.x} ${fC.y} L${g.textCoor.x} ${g.textCoor.y}`} />
+                <path
+                  className="la-vz-label-line"
+                  d={`M${fC.x} ${fC.y} L${g.textCoor.x} ${g.textCoor.y}`}
+                  style={circularLabelLine}
+                />
               )}
             </>
           );
@@ -312,7 +320,7 @@ export class Labels extends React.Component<LabelsProps, LabelsState> {
                   id={first.id}
                   {...g.textCoor}
                   dominantBaseline="middle"
-                  style={svgText}
+                  style={circularLabel}
                   textAnchor={g.textAnchor}
                 >
                   {g.name}
@@ -331,10 +339,10 @@ export class Labels extends React.Component<LabelsProps, LabelsState> {
                 className="la-vz-circular-label"
                 dominantBaseline="middle"
                 id={first.id}
+                style={circularLabel}
                 textAnchor={g.textAnchor}
                 onMouseEnter={() => this.setHoveredGroup(first.id || "")}
                 {...g.textCoor}
-                style={svgText}
               >
                 {g.name}
               </text>

--- a/src/Circular/Labels.tsx
+++ b/src/Circular/Labels.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { CHAR_WIDTH } from "../SeqViewerContainer";
 import { Coor, Size } from "../elements";
-import { circularLabel, circularLabelLine, svgText } from "../style";
+import { circularLabel, circularLabelLine } from "../style";
 import { GenArcFunc, ILabel, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 import { WrappedGroupLabel } from "./WrappedGroupLabel";
 

--- a/src/Circular/Labels.tsx
+++ b/src/Circular/Labels.tsx
@@ -4,7 +4,7 @@ import { CHAR_WIDTH } from "../SeqViewerContainer";
 import { Coor, Size } from "../elements";
 import { circularLabel, circularLabelLine } from "../style";
 import { GenArcFunc, ILabel, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
-import { WrappedGroupLabel } from "./WrappedGroupLabel";
+import { WrappedGroupLabel, setHoveredLabelUnderline } from "./WrappedGroupLabel";
 
 interface LabelWithCoors {
   label: ILabel;
@@ -322,6 +322,8 @@ export class Labels extends React.Component<LabelsProps, LabelsState> {
                   dominantBaseline="middle"
                   style={circularLabel}
                   textAnchor={g.textAnchor}
+                  onMouseEnter={() => setHoveredLabelUnderline(first.id || "", true)}
+                  onMouseLeave={() => setHoveredLabelUnderline(first.id || "", false)}
                 >
                   {g.name}
                 </text>

--- a/src/Circular/Labels.tsx
+++ b/src/Circular/Labels.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { CHAR_WIDTH } from "../SeqViewerContainer";
 import { Coor, Size } from "../elements";
+import { svgText } from "../style";
 import { GenArcFunc, ILabel, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 import { WrappedGroupLabel } from "./WrappedGroupLabel";
 
@@ -312,6 +313,7 @@ export class Labels extends React.Component<LabelsProps, LabelsState> {
                   {...g.textCoor}
                   dominantBaseline="middle"
                   textAnchor={g.textAnchor}
+                  style={svgText}
                 >
                   {g.name}
                 </text>
@@ -332,6 +334,7 @@ export class Labels extends React.Component<LabelsProps, LabelsState> {
                 textAnchor={g.textAnchor}
                 onMouseEnter={() => this.setHoveredGroup(first.id || "")}
                 {...g.textCoor}
+                style={svgText}
               >
                 {g.name}
               </text>

--- a/src/Circular/Selection.tsx
+++ b/src/Circular/Selection.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { Coor } from "../elements";
 import SelectionContext from "../selectionContext";
-import { highlight, selectionEdge } from "../style";
+import { highlight, selection, selectionEdge } from "../style";
 import { GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 interface CircularSelectionProps {
@@ -97,7 +97,7 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
             })}
             shapeRendering="auto"
             stroke="none"
-            style={highlight}
+            style={selection}
             transform={getRotation(start)}
           />
         )}

--- a/src/Circular/Selection.tsx
+++ b/src/Circular/Selection.tsx
@@ -104,9 +104,9 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
         <path
           className="la-vz-selection-edge"
           d={edgePath}
+          strokeWidth={1}
           style={selectionEdge}
           transform={getRotation(start)}
-          strokeWidth={1}
         />
         {selLength && (
           <path className="la-vz-selection-edge" d={edgePath} style={selectionEdge} transform={getRotation(end)} />

--- a/src/Circular/Selection.tsx
+++ b/src/Circular/Selection.tsx
@@ -87,6 +87,7 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
       <g>
         {selLength && (
           <path
+            className="la-vz-selection"
             d={genArc({
               innerRadius: bottomR,
               largeArc: lArc,
@@ -94,16 +95,15 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
               outerRadius: topR,
               sweepFWD: sFlagF,
             })}
-            className="la-vz-selection"
             shapeRendering="auto"
             stroke="none"
             style={highlight}
             transform={getRotation(start)}
           />
         )}
-        <path d={edgePath} style={selectionEdge} transform={getRotation(start)} className="la-vz-selection-edge" />
+        <path className="la-vz-selection-edge" d={edgePath} style={selectionEdge} transform={getRotation(start)} />
         {selLength && (
-          <path d={edgePath} style={selectionEdge} transform={getRotation(end)} className="la-vz-selection-edge" />
+          <path className="la-vz-selection-edge" d={edgePath} style={selectionEdge} transform={getRotation(end)} />
         )}
       </g>
     );

--- a/src/Circular/Selection.tsx
+++ b/src/Circular/Selection.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { Coor } from "../elements";
 import SelectionContext from "../selectionContext";
+import { highlight, selectionEdge } from "../style";
 import { GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 interface CircularSelectionProps {
@@ -86,7 +87,7 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
       <g>
         {selLength && (
           <path
-            className="la-vz-selection"
+            style={highlight}
             d={genArc({
               innerRadius: bottomR,
               largeArc: lArc,
@@ -99,22 +100,8 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
             transform={getRotation(start)}
           />
         )}
-        <path
-          className="la-vz-selection-edge"
-          d={edgePath}
-          shapeRendering="geometricPrecision"
-          strokeWidth={1}
-          transform={getRotation(start)}
-        />
-        {selLength && (
-          <path
-            className="la-vz-selection-edge"
-            d={edgePath}
-            shapeRendering="geometricPrecision"
-            strokeWidth={1}
-            transform={getRotation(end)}
-          />
-        )}
+        <path d={edgePath} transform={getRotation(start)} style={selectionEdge} />
+        {selLength && <path d={edgePath} transform={getRotation(end)} style={selectionEdge} />}
       </g>
     );
   }

--- a/src/Circular/Selection.tsx
+++ b/src/Circular/Selection.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { Coor } from "../elements";
 import SelectionContext from "../selectionContext";
-import { highlight, selection, selectionEdge } from "../style";
+import { selection, selectionEdge } from "../style";
 import { GenArcFunc, RENDER_SEQ_LENGTH_CUTOFF } from "./Circular";
 
 interface CircularSelectionProps {
@@ -101,7 +101,13 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
             transform={getRotation(start)}
           />
         )}
-        <path className="la-vz-selection-edge" d={edgePath} style={selectionEdge} transform={getRotation(start)} />
+        <path
+          className="la-vz-selection-edge"
+          d={edgePath}
+          style={selectionEdge}
+          transform={getRotation(start)}
+          strokeWidth={1}
+        />
         {selLength && (
           <path className="la-vz-selection-edge" d={edgePath} style={selectionEdge} transform={getRotation(end)} />
         )}

--- a/src/Circular/Selection.tsx
+++ b/src/Circular/Selection.tsx
@@ -94,14 +94,17 @@ export class Selection extends React.PureComponent<CircularSelectionProps> {
               outerRadius: topR,
               sweepFWD: sFlagF,
             })}
+            className="la-vz-selection"
             shapeRendering="auto"
             stroke="none"
             style={highlight}
             transform={getRotation(start)}
           />
         )}
-        <path d={edgePath} style={selectionEdge} transform={getRotation(start)} />
-        {selLength && <path d={edgePath} style={selectionEdge} transform={getRotation(end)} />}
+        <path d={edgePath} style={selectionEdge} transform={getRotation(start)} className="la-vz-selection-edge" />
+        {selLength && (
+          <path d={edgePath} style={selectionEdge} transform={getRotation(end)} className="la-vz-selection-edge" />
+        )}
       </g>
     );
   }

--- a/src/Circular/WrappedGroupLabel.tsx
+++ b/src/Circular/WrappedGroupLabel.tsx
@@ -122,6 +122,8 @@ export const WrappedGroupLabel = (props: WrappedGroupLabelProps) => {
                   style={circularLabel}
                   tabIndex={-1}
                   y={groupCoor.y + (i + 0.5) * lineHeight}
+                  onMouseLeave={() => setHoveredLabelUnderline(l.id || "", false)}
+                  onMouseOver={() => setHoveredLabelUnderline(l.id || "", true)}
                 >
                   {l.name}
                 </tspan>
@@ -134,4 +136,16 @@ export const WrappedGroupLabel = (props: WrappedGroupLabelProps) => {
       <rect fill="none" height={rectHeight} stroke="black" strokeWidth={1.5} width={rectWidth} {...rectCoor} />
     </g>
   );
+};
+
+export const setHoveredLabelUnderline = (id: string, underline: boolean) => {
+  if (!document) return;
+
+  const element = document.getElementById(id);
+  if (!element) return;
+  if (underline) {
+    element.style.textDecoration = "underline";
+  } else {
+    element.style.textDecoration = "none";
+  }
 };

--- a/src/Circular/WrappedGroupLabel.tsx
+++ b/src/Circular/WrappedGroupLabel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { CHAR_WIDTH } from "../SeqViewerContainer";
+import { svgText } from "../style";
 import { ILabel } from "./Circular";
 import { GroupedLabelsWithCoors } from "./Labels";
 
@@ -15,7 +16,7 @@ interface WrappedGroupLabelProps {
 }
 
 /**
- * a component that groups several other labels together so they're all viewable at once
+ * Groups several other labels together so they're all viewable at once
  *
  * given the currently active annotation block, with multiple annotations and enzymes,
  * render each in a single "block", which is a g element with a rect "containing" the
@@ -103,7 +104,7 @@ export const WrappedGroupLabel = (props: WrappedGroupLabelProps) => {
     <g key={key} onMouseLeave={() => setHoveredGroup("")}>
       <path className="la-vz-label-line" d={linePath} />
       <rect fill="white" height={rectHeight} stroke="none" width={rectWidth} {...rectCoor} />
-      <text {...groupCoor}>
+      <text {...groupCoor} style={svgText}>
         {labelRows.map((r, i) => (
           // turn each group of label rows into a text span
           // that's vertically spaced from the row above it

--- a/src/Circular/WrappedGroupLabel.tsx
+++ b/src/Circular/WrappedGroupLabel.tsx
@@ -49,7 +49,7 @@ export const WrappedGroupLabel = (props: WrappedGroupLabelProps) => {
       const splitRegex = new RegExp(`.{1,${maxCharPerRow}}`, "g");
       const splitLabelNameRows = l.name.match(splitRegex) || [];
       if (splitLabelNameRows.length) {
-        splitLabelNameRows.forEach(splitLabel => {
+        splitLabelNameRows.forEach((splitLabel: string) => {
           acc.push([{ ...l, name: splitLabel.trim() }]);
         });
         return acc;
@@ -118,8 +118,8 @@ export const WrappedGroupLabel = (props: WrappedGroupLabelProps) => {
                 <tspan
                   className="la-vz-circular-label"
                   dominantBaseline="middle"
-                  style={circularLabel}
                   id={l.id}
+                  style={circularLabel}
                   tabIndex={-1}
                   y={groupCoor.y + (i + 0.5) * lineHeight}
                 >

--- a/src/Circular/WrappedGroupLabel.tsx
+++ b/src/Circular/WrappedGroupLabel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { CHAR_WIDTH } from "../SeqViewerContainer";
-import { svgText } from "../style";
+import { circularLabel, svgText } from "../style";
 import { ILabel } from "./Circular";
 import { GroupedLabelsWithCoors } from "./Labels";
 
@@ -118,6 +118,7 @@ export const WrappedGroupLabel = (props: WrappedGroupLabelProps) => {
                 <tspan
                   className="la-vz-circular-label"
                   dominantBaseline="middle"
+                  style={circularLabel}
                   id={l.id}
                   tabIndex={-1}
                   y={groupCoor.y + (i + 0.5) * lineHeight}

--- a/src/EventHandler.tsx
+++ b/src/EventHandler.tsx
@@ -256,6 +256,14 @@ export class EventHandler extends React.PureComponent<EventsHandlerProps> {
       onMouseDown={this.handleMouseEvent}
       onMouseMove={this.props.handleMouseEvent}
       onMouseUp={this.handleMouseEvent}
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        height: "100%",
+        outline: "none",
+        position: "absolute",
+        width: "100%",
+      }}
     >
       {this.props.children}
     </div>

--- a/src/EventHandler.tsx
+++ b/src/EventHandler.tsx
@@ -220,7 +220,7 @@ export class EventHandler extends React.PureComponent<EventsHandlerProps> {
    *
    * if it is a regular click, pass on as normal
    */
-  handleMouseEvent = (e: React.MouseEvent) => {
+  handleMouseEvent = (e: React.MouseEvent<HTMLDivElement>) => {
     const { handleMouseEvent } = this.props;
 
     if (e.type === "mouseup") {

--- a/src/Linear/Annotations.tsx
+++ b/src/Linear/Annotations.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { InputRefFunc } from "../SelectionHandler";
 import { COLOR_BORDER_MAP, darkerColor } from "../colors";
 import { NameRange } from "../elements";
+import { svgText } from "../style";
 import { FindXAndWidthElementType } from "./SeqBlock";
 
 const hoverOtherAnnotationRows = (className: string, opacity: number) => {
@@ -230,6 +231,7 @@ const SingleNamedElement = (props: {
           }}
           onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
           onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
+          style={svgText}
         >
           {name}
         </text>

--- a/src/Linear/Annotations.tsx
+++ b/src/Linear/Annotations.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { InputRefFunc } from "../SelectionHandler";
 import { COLOR_BORDER_MAP, darkerColor } from "../colors";
 import { NameRange } from "../elements";
-import { svgText } from "../style";
+import { annotation, annotationLabel, svgText } from "../style";
 import { FindXAndWidthElementType } from "./SeqBlock";
 
 const hoverOtherAnnotationRows = (className: string, opacity: number) => {
@@ -211,6 +211,7 @@ const SingleNamedElement = (props: {
         }}
         onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
         onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
+        style={annotation}
       />
 
       {nameFits && (
@@ -220,7 +221,6 @@ const SingleNamedElement = (props: {
           dominantBaseline="middle"
           fontSize={12}
           id={element.id}
-          style={svgText}
           textAnchor="middle"
           x={width / 2}
           y={height / 2 + 1}
@@ -232,6 +232,7 @@ const SingleNamedElement = (props: {
           }}
           onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
           onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
+          style={annotationLabel}
         >
           {name}
         </text>

--- a/src/Linear/Annotations.tsx
+++ b/src/Linear/Annotations.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { InputRefFunc } from "../SelectionHandler";
 import { COLOR_BORDER_MAP, darkerColor } from "../colors";
 import { NameRange } from "../elements";
-import { annotation, annotationLabel, svgText } from "../style";
+import { annotation, annotationLabel } from "../style";
 import { FindXAndWidthElementType } from "./SeqBlock";
 
 const hoverOtherAnnotationRows = (className: string, opacity: number) => {
@@ -203,6 +203,7 @@ const SingleNamedElement = (props: {
         fill={color}
         id={element.id}
         stroke={color ? COLOR_BORDER_MAP[color] || darkerColor(color) : "gray"}
+        style={annotation}
         onBlur={() => {
           // do nothing
         }}
@@ -211,7 +212,6 @@ const SingleNamedElement = (props: {
         }}
         onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
         onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
-        style={annotation}
       />
 
       {nameFits && (
@@ -221,6 +221,7 @@ const SingleNamedElement = (props: {
           dominantBaseline="middle"
           fontSize={12}
           id={element.id}
+          style={annotationLabel}
           textAnchor="middle"
           x={width / 2}
           y={height / 2 + 1}
@@ -232,7 +233,6 @@ const SingleNamedElement = (props: {
           }}
           onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
           onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
-          style={annotationLabel}
         >
           {name}
         </text>

--- a/src/Linear/CutSites.tsx
+++ b/src/Linear/CutSites.tsx
@@ -101,23 +101,23 @@ export const CutSites = (props: {
             {c.top.render && (
               <path
                 className={`la-vz-cut-site ${c.c.id}`}
-                style={cutSite}
                 d={`M ${c.top.x} ${lineYDiff} L ${c.top.x} ${lineYDiff + lineHeight}`}
+                style={cutSite}
               />
             )}
             {c.connector.render && zoom > 10 && (
               <path
                 className={`la-vz-cut-site ${c.c.id}`}
-                style={cutSite}
                 d={`M ${c.connector.x} ${lineYDiff + lineHeight}
                     L ${c.connector.x + c.connector.width} ${lineYDiff + lineHeight}`}
+                style={cutSite}
               />
             )}
             {c.bottom.render && zoom > 10 && (
               <path
                 className={`la-vz-cut-site ${c.c.id}`}
-                style={cutSite}
                 d={`M ${c.bottom.x} ${lineYDiff + lineHeight} L ${c.bottom.x} ${lineYDiff + 2 * lineHeight}`}
+                style={cutSite}
               />
             )}
           </g>

--- a/src/Linear/CutSites.tsx
+++ b/src/Linear/CutSites.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { InputRefFunc } from "../SelectionHandler";
 import { CHAR_WIDTH } from "../SeqViewerContainer";
 import { CutSite, Size } from "../elements";
+import { cutSiteHighlight, svgText } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 /**
@@ -68,6 +69,7 @@ export const CutSites = (props: {
                 onFocus={() => 0}
                 onMouseOut={() => onCutSiteHover(c.c.id, false)}
                 onMouseOver={() => onCutSiteHover(c.c.id, true)}
+                style={{ ...svgText, cursor: "pointer", fontSize: 12 }}
               >
                 {c.label.text}
               </text>
@@ -89,7 +91,7 @@ export const CutSites = (props: {
                     L ${c.highlight.x + c.highlight.width} ${lineYDiff}
                     L ${c.highlight.x + c.highlight.width} ${lineYDiff + 2 * lineHeight}
                     L ${c.highlight.x} ${lineYDiff + 2 * lineHeight} Z`}
-                style={c.c.color?.length ? { fill: c.c.color } : {}}
+                style={c.c.color?.length ? { ...cutSiteHighlight, fill: c.c.color } : cutSiteHighlight}
                 onMouseOut={() => onCutSiteHover(c.c.id, false)}
                 onMouseOver={() => onCutSiteHover(c.c.id, true)}
               />

--- a/src/Linear/CutSites.tsx
+++ b/src/Linear/CutSites.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { InputRefFunc } from "../SelectionHandler";
 import { CHAR_WIDTH } from "../SeqViewerContainer";
 import { CutSite, Size } from "../elements";
-import { cutSiteHighlight, svgText } from "../style";
+import { cutSite, cutSiteHighlight, svgText } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 /**
@@ -101,12 +101,14 @@ export const CutSites = (props: {
             {c.top.render && (
               <path
                 className={`la-vz-cut-site ${c.c.id}`}
+                style={cutSite}
                 d={`M ${c.top.x} ${lineYDiff} L ${c.top.x} ${lineYDiff + lineHeight}`}
               />
             )}
             {c.connector.render && zoom > 10 && (
               <path
                 className={`la-vz-cut-site ${c.c.id}`}
+                style={cutSite}
                 d={`M ${c.connector.x} ${lineYDiff + lineHeight}
                     L ${c.connector.x + c.connector.width} ${lineYDiff + lineHeight}`}
               />
@@ -114,6 +116,7 @@ export const CutSites = (props: {
             {c.bottom.render && zoom > 10 && (
               <path
                 className={`la-vz-cut-site ${c.c.id}`}
+                style={cutSite}
                 d={`M ${c.bottom.x} ${lineYDiff + lineHeight} L ${c.bottom.x} ${lineYDiff + 2 * lineHeight}`}
               />
             )}

--- a/src/Linear/Find.tsx
+++ b/src/Linear/Find.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { InputRefFunc } from "../SelectionHandler";
 import { Range } from "../elements";
 import { randomID } from "../sequence";
+import { search } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 /**
@@ -112,7 +113,7 @@ const FindBlock = ({
       shapeRendering="crispEdges"
       stroke={listenerOnly ? "none" : "rgba(0, 0, 0, 0.5)"}
       strokeWidth={1}
-      style={listenerOnly ? { fill: "transparent" } : {}}
+      style={listenerOnly ? { fill: "transparent" } : search}
       width={width}
       x={x}
       y={y}

--- a/src/Linear/Highlights.tsx
+++ b/src/Linear/Highlights.tsx
@@ -45,20 +45,19 @@ const SingleHighlight = (props: {
 }) => {
   const { width, x } = props.findXAndWidth(props.index, props.highlight, props.highlights);
 
-  const fill = highlightStyle.fill;
+  let fill = highlightStyle.fill;
   if (props.listenerOnly) {
-    // fill = "transparent";
+    fill = "transparent";
   } else if (props.highlight.color?.length) {
-    // fill = props.highlight.color;
+    fill = props.highlight.color;
   }
 
   const rectProps = {
     className: "la-vz-highlight",
-    fill,
     height: props.lineHeight,
     id: props.highlight.id,
     stroke: props.listenerOnly ? "none" : "rgba(0, 0, 0, 0.5)",
-    style: highlightStyle,
+    style: { ...highlightStyle, fill },
     width: width,
     x: x,
   };
@@ -74,7 +73,6 @@ const SingleHighlight = (props: {
           viewer: "LINEAR",
         })}
         {...rectProps}
-        fill="rgba(255, 251, 7, 0.25)"
         y={props.indexYDiff}
       />
       <rect
@@ -86,7 +84,6 @@ const SingleHighlight = (props: {
           viewer: "LINEAR",
         })}
         {...rectProps}
-        fill="rgba(255, 251, 7, 0.25)"
         y={props.compYDiff}
       />
     </>

--- a/src/Linear/Highlights.tsx
+++ b/src/Linear/Highlights.tsx
@@ -53,6 +53,7 @@ const SingleHighlight = (props: {
   }
 
   const rectProps = {
+    className: "la-vz-highlight",
     height: props.lineHeight,
     id: props.highlight.id,
     stroke: props.listenerOnly ? "none" : "rgba(0, 0, 0, 0.5)",

--- a/src/Linear/Highlights.tsx
+++ b/src/Linear/Highlights.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { NameRange } from "../elements";
-import { highlight } from "../style";
+import { highlight as highlightStyle } from "../style";
 import { FindXAndWidthElementType } from "./SeqBlock";
 
 /**
@@ -45,11 +45,11 @@ const SingleHighlight = (props: {
 }) => {
   const { width, x } = props.findXAndWidth(props.index, props.highlight, props.highlights);
 
-  let highlightStyle = {};
+  let fill = highlightStyle.fill;
   if (props.listenerOnly) {
-    highlightStyle = { fill: "transparent" };
+    // fill = "transparent";
   } else if (props.highlight.color?.length) {
-    highlightStyle = { fill: props.highlight.color };
+    // fill = props.highlight.color;
   }
 
   const rectProps = {
@@ -57,10 +57,8 @@ const SingleHighlight = (props: {
     height: props.lineHeight,
     id: props.highlight.id,
     stroke: props.listenerOnly ? "none" : "rgba(0, 0, 0, 0.5)",
-    style: {
-      ...highlight,
-      ...highlightStyle,
-    },
+    fill,
+    style: highlightStyle,
     width: width,
     x: x,
   };
@@ -76,6 +74,7 @@ const SingleHighlight = (props: {
           viewer: "LINEAR",
         })}
         {...rectProps}
+        fill="rgba(255, 251, 7, 0.25)"
         y={props.indexYDiff}
       />
       <rect
@@ -87,6 +86,7 @@ const SingleHighlight = (props: {
           viewer: "LINEAR",
         })}
         {...rectProps}
+        fill="rgba(255, 251, 7, 0.25)"
         y={props.compYDiff}
       />
     </>

--- a/src/Linear/Highlights.tsx
+++ b/src/Linear/Highlights.tsx
@@ -2,12 +2,13 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { NameRange } from "../elements";
+import { highlight } from "../style";
 import { FindXAndWidthElementType } from "./SeqBlock";
 
 /**
- * Render rectangles aroun highlighted ranges.
+ * Render rectangles around highlighted ranges.
  */
-const Highlights = (props: {
+export const Highlights = (props: {
   compYDiff: number;
   findXAndWidth: FindXAndWidthElementType;
   firstBase: number;
@@ -27,8 +28,6 @@ const Highlights = (props: {
     ))}
   </>
 );
-
-export default Highlights;
 
 const SingleHighlight = (props: {
   compYDiff: number;
@@ -54,13 +53,13 @@ const SingleHighlight = (props: {
   }
 
   const rectProps = {
-    className: "la-vz-highlight",
-    cursor: "pointer",
     height: props.lineHeight,
     id: props.highlight.id,
     stroke: props.listenerOnly ? "none" : "rgba(0, 0, 0, 0.5)",
-    strokeWidth: 1,
-    style: highlightStyle,
+    style: {
+      ...highlight,
+      ...highlightStyle,
+    },
     width: width,
     x: x,
   };
@@ -77,6 +76,7 @@ const SingleHighlight = (props: {
         })}
         {...rectProps}
         y={props.indexYDiff}
+        style={highlight}
       />
       <rect
         key={`linear-highlight-${props.highlight.id}-bottom`}
@@ -88,6 +88,7 @@ const SingleHighlight = (props: {
         })}
         {...rectProps}
         y={props.compYDiff}
+        style={highlight}
       />
     </>
   );

--- a/src/Linear/Highlights.tsx
+++ b/src/Linear/Highlights.tsx
@@ -48,7 +48,7 @@ const SingleHighlight = (props: {
   let highlightStyle = {};
   if (props.listenerOnly) {
     highlightStyle = { fill: "transparent" };
-  } else if (props.highlight.color) {
+  } else if (props.highlight.color?.length) {
     highlightStyle = { fill: props.highlight.color };
   }
 
@@ -76,7 +76,6 @@ const SingleHighlight = (props: {
           viewer: "LINEAR",
         })}
         {...rectProps}
-        style={highlight}
         y={props.indexYDiff}
       />
       <rect
@@ -88,7 +87,6 @@ const SingleHighlight = (props: {
           viewer: "LINEAR",
         })}
         {...rectProps}
-        style={highlight}
         y={props.compYDiff}
       />
     </>

--- a/src/Linear/Highlights.tsx
+++ b/src/Linear/Highlights.tsx
@@ -45,7 +45,7 @@ const SingleHighlight = (props: {
 }) => {
   const { width, x } = props.findXAndWidth(props.index, props.highlight, props.highlights);
 
-  let fill = highlightStyle.fill;
+  const fill = highlightStyle.fill;
   if (props.listenerOnly) {
     // fill = "transparent";
   } else if (props.highlight.color?.length) {
@@ -54,10 +54,10 @@ const SingleHighlight = (props: {
 
   const rectProps = {
     className: "la-vz-highlight",
+    fill,
     height: props.lineHeight,
     id: props.highlight.id,
     stroke: props.listenerOnly ? "none" : "rgba(0, 0, 0, 0.5)",
-    fill,
     style: highlightStyle,
     width: width,
     x: x,

--- a/src/Linear/Index.tsx
+++ b/src/Linear/Index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { SeqType, Size } from "../elements";
+import { indexLine, indexTick, indexTickLabel, svgText } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface IndexProps {
@@ -93,8 +94,13 @@ export default class Index extends React.PureComponent<IndexProps> {
 
       return (
         <React.Fragment key={p}>
-          <path className="la-vz-index-tick" d="M 0 0 L 0 7" transform={transTick} />
-          <text className="la-vz-index-tick-label" dominantBaseline="hanging" fontSize={12} transform={transText}>
+          <path className="la-vz-index-tick" d="M 0 0 L 0 7" transform={transTick} style={indexTick} />
+          <text
+            className="la-vz-index-tick-label"
+            dominantBaseline="hanging"
+            transform={transText}
+            style={indexTickLabel}
+          >
             {p}
           </text>
         </React.Fragment>
@@ -110,7 +116,7 @@ export default class Index extends React.PureComponent<IndexProps> {
 
     return (
       <g transform={`translate(0, ${yDiff})`}>
-        <path className="la-vz-index-line" d={`M 0 1 L ${x + width} 1`} />
+        <path className="la-vz-index-line" d={`M 0 1 L ${x + width} 1`} style={indexLine} />
         {this.genTicks()}
       </g>
     );

--- a/src/Linear/Index.tsx
+++ b/src/Linear/Index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { SeqType, Size } from "../elements";
-import { indexLine, indexTick, indexTickLabel, svgText } from "../style";
+import { indexLine, indexTick, indexTickLabel } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface IndexProps {

--- a/src/Linear/InfiniteScroll.tsx
+++ b/src/Linear/InfiniteScroll.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import CentralIndexContext from "../centralIndexContext";
 import { Size } from "../elements";
 import { isEqual } from "../isEqual";
+import { linearScroller } from "../style";
 
 interface InfiniteScrollProps {
   blockHeights: number[];
@@ -297,8 +298,9 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
         }}
         onMouseOver={this.handleMouseOver}
         onScroll={this.handleScrollOrResize}
+        style={linearScroller}
       >
-        <div ref={this.insideDOM} className="la-vz-seqblock-container" style={{ height }}>
+        <div ref={this.insideDOM} className="la-vz-seqblock-container" style={{ height, width: "100%" }}>
           <div className="la-vz-seqblock-padding-top" style={{ height: spaceAbove, width: width || 0 }} />
           {visibleBlocks.map(i => seqBlocks[i])}
         </div>

--- a/src/Linear/InfiniteScroll.tsx
+++ b/src/Linear/InfiniteScroll.tsx
@@ -18,6 +18,11 @@ interface InfiniteScrollState {
   visibleBlocks: number[];
 }
 
+interface InfiniteScrollSnapshot {
+  blockIndex: number;
+  blockY: number;
+}
+
 /**
  * InfiniteScroll is a wrapper around the seqBlocks. Renders only the seqBlocks that are
  * within the range of the current dom viewerport
@@ -48,7 +53,11 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
     window.addEventListener("resize", this.handleScrollOrResize);
   };
 
-  componentDidUpdate = (prevProps: InfiniteScrollProps, prevState: InfiniteScrollState, snapshot: any) => {
+  componentDidUpdate = (
+    prevProps: InfiniteScrollProps,
+    prevState: InfiniteScrollState,
+    snapshot: InfiniteScrollSnapshot
+  ) => {
     if (!this.scroller.current) {
       // scroller not mounted yet
       return;
@@ -73,7 +82,7 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
   /**
    * more info at: https://reactjs.org/docs/react-component.html#getsnapshotbeforeupdate
    */
-  getSnapshotBeforeUpdate = (prevProps: InfiniteScrollProps) => {
+  getSnapshotBeforeUpdate = (prevProps: InfiniteScrollProps): InfiniteScrollSnapshot => {
     // find the current top block
     const top = this.scroller.current ? this.scroller.current.scrollTop : 0;
 
@@ -156,7 +165,7 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
    * the component has mounted to the DOM or updated, and the window should be scrolled downwards
    * so that the central index is visible
    */
-  restoreSnapshot = snapshot => {
+  restoreSnapshot = (snapshot: InfiniteScrollSnapshot) => {
     if (!this.scroller.current) {
       return;
     }
@@ -293,12 +302,12 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
         ref={this.scroller}
         className="la-vz-linear-scroller"
         data-testid="la-vz-viewer-linear"
+        style={linearScroller}
         onFocus={() => {
           // do nothing
         }}
         onMouseOver={this.handleMouseOver}
         onScroll={this.handleScrollOrResize}
-        style={linearScroller}
       >
         <div ref={this.insideDOM} className="la-vz-seqblock-container" style={{ height, width: "100%" }}>
           <div className="la-vz-seqblock-padding-top" style={{ height: spaceAbove, width: width || 0 }} />

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -98,8 +98,8 @@ class Edges extends React.PureComponent<EdgesProps> {
       <g>
         {startEdge !== null && (
           <rect
-            data-testid="la-vz-selection-edge"
             className="la-vz-selection-edge"
+            data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
             strokeWidth={0}
@@ -111,8 +111,8 @@ class Edges extends React.PureComponent<EdgesProps> {
         )}
         {lastEdge !== null && (
           <rect
-            data-testid="la-vz-selection-edge"
             className="la-vz-selection-edge"
+            data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
             strokeWidth={0}

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import SelectionContext from "../selectionContext";
 import { randomid } from "../sequence";
+import { selection, selectionEdge } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface EdgesProps {
@@ -97,7 +98,7 @@ class Edges extends React.PureComponent<EdgesProps> {
       <g>
         {startEdge !== null && (
           <rect
-            className="la-vz-selection-edge"
+            style={selectionEdge}
             data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
@@ -109,7 +110,7 @@ class Edges extends React.PureComponent<EdgesProps> {
         )}
         {lastEdge !== null && (
           <rect
-            className="la-vz-selection-edge"
+            style={selectionEdge}
             data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
@@ -162,11 +163,10 @@ class Block extends React.PureComponent<BlockProps> {
 
     // props shared between all 3 possible components.
     const blockProps = {
-      className: "la-vz-selection",
       "data-testid": "la-vz-selection-block",
       height: selectHeight,
-      shapeRendering: "auto",
       y: -5,
+      style: selection,
     };
 
     let x: number | null = null;

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -102,11 +102,11 @@ class Edges extends React.PureComponent<EdgesProps> {
             data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
+            strokeWidth={0}
             style={selectionEdge}
+            width={1}
             x={x}
             y={-5}
-            width={1}
-            strokeWidth={0}
           />
         )}
         {lastEdge !== null && (
@@ -115,11 +115,11 @@ class Edges extends React.PureComponent<EdgesProps> {
             data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
+            strokeWidth={0}
             style={selectionEdge}
+            width={1}
             x={secondEdgeX}
             y={-5}
-            width={1}
-            strokeWidth={0}
           />
         )}
       </g>

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -99,6 +99,7 @@ class Edges extends React.PureComponent<EdgesProps> {
         {startEdge !== null && (
           <rect
             data-testid="la-vz-selection-edge"
+            className="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
             strokeWidth={0}
@@ -111,6 +112,7 @@ class Edges extends React.PureComponent<EdgesProps> {
         {lastEdge !== null && (
           <rect
             data-testid="la-vz-selection-edge"
+            className="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
             strokeWidth={0}

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import SelectionContext from "../selectionContext";
 import { randomID } from "../sequence";
-import { highlight, selection, selectionEdge } from "../style";
+import { selection, selectionEdge } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface EdgesProps {

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -102,9 +102,7 @@ class Edges extends React.PureComponent<EdgesProps> {
             data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
-            strokeWidth={0}
             style={selectionEdge}
-            width={1}
             x={x}
             y={-5}
           />
@@ -115,9 +113,7 @@ class Edges extends React.PureComponent<EdgesProps> {
             data-testid="la-vz-selection-edge"
             height={selectEdgeHeight}
             shapeRendering="crispEdges"
-            strokeWidth={0}
             style={selectionEdge}
-            width={1}
             x={secondEdgeX}
             y={-5}
           />

--- a/src/Linear/Selection.tsx
+++ b/src/Linear/Selection.tsx
@@ -105,6 +105,8 @@ class Edges extends React.PureComponent<EdgesProps> {
             style={selectionEdge}
             x={x}
             y={-5}
+            width={1}
+            strokeWidth={0}
           />
         )}
         {lastEdge !== null && (
@@ -116,6 +118,8 @@ class Edges extends React.PureComponent<EdgesProps> {
             style={selectionEdge}
             x={secondEdgeX}
             y={-5}
+            width={1}
+            strokeWidth={0}
           />
         )}
       </g>

--- a/src/Linear/SeqBlock.test.tsx
+++ b/src/Linear/SeqBlock.test.tsx
@@ -21,9 +21,13 @@ const defaultProps = {
   },
   key: "",
   lineHeight: 14,
-  mouseEvent: () => {},
+  mouseEvent: () => {
+    // do nothing
+  },
   name: "",
-  onUnmount: () => {},
+  onUnmount: () => {
+    // do nothing
+  },
   reversePrimerRows: [],
   searchRows: [],
   selection: {},

--- a/src/Linear/SeqBlock.tsx
+++ b/src/Linear/SeqBlock.tsx
@@ -303,11 +303,11 @@ export class SeqBlock extends React.PureComponent<SeqBlockProps> {
         height={blockHeight}
         id={id}
         overflow="visible"
+        style={seqBlock}
         width={size.width >= 0 ? size.width : 0}
         onMouseDown={handleMouseEvent}
         onMouseMove={handleMouseEvent}
         onMouseUp={handleMouseEvent}
-        style={seqBlock}
       >
         {showIndex && (
           <IndexRow

--- a/src/Linear/SeqBlock.tsx
+++ b/src/Linear/SeqBlock.tsx
@@ -2,10 +2,11 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { Annotation, CutSite, Highlight, NameRange, Range, SeqType, Size, Translation } from "../elements";
+import { svgText } from "../style";
 import AnnotationRows from "./Annotations";
 import { CutSites } from "./CutSites";
 import Find from "./Find";
-import Highlights from "./Highlights";
+import { Highlights } from "./Highlights";
 import IndexRow from "./Index";
 import Selection from "./Selection";
 import { TranslationRows } from "./Translations";
@@ -304,6 +305,7 @@ export class SeqBlock extends React.PureComponent<SeqBlockProps> {
         onMouseDown={handleMouseEvent}
         onMouseMove={handleMouseEvent}
         onMouseUp={handleMouseEvent}
+        overflow="visible"
       >
         {showIndex && (
           <IndexRow
@@ -396,6 +398,7 @@ export class SeqBlock extends React.PureComponent<SeqBlockProps> {
             data-testid="la-vz-seq"
             id={id}
             transform={`translate(0, ${indexYDiff + lineHeight / 2})`}
+            style={svgText}
           >
             {seq.split("").map(this.seqTextSpan)}
           </text>
@@ -407,6 +410,7 @@ export class SeqBlock extends React.PureComponent<SeqBlockProps> {
             data-testid="la-vz-comp-seq"
             id={id}
             transform={`translate(0, ${compYDiff + lineHeight / 2})`}
+            style={svgText}
           >
             {compSeq.split("").map(this.seqTextSpan)}
           </text>

--- a/src/Linear/SeqBlock.tsx
+++ b/src/Linear/SeqBlock.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { InputRefFunc } from "../SelectionHandler";
 import { Annotation, CutSite, Highlight, NameRange, Range, SeqType, Size, Translation } from "../elements";
-import { svgText } from "../style";
+import { seqBlock, svgText } from "../style";
 import AnnotationRows from "./Annotations";
 import { CutSites } from "./CutSites";
 import Find from "./Find";
@@ -307,6 +307,7 @@ export class SeqBlock extends React.PureComponent<SeqBlockProps> {
         onMouseDown={handleMouseEvent}
         onMouseMove={handleMouseEvent}
         onMouseUp={handleMouseEvent}
+        style={seqBlock}
       >
         {showIndex && (
           <IndexRow

--- a/src/Linear/Translations.tsx
+++ b/src/Linear/Translations.tsx
@@ -4,7 +4,7 @@ import { InputRefFunc } from "../SelectionHandler";
 import { borderColorByIndex, colorByIndex } from "../colors";
 import { SeqType, Translation } from "../elements";
 import { randomID } from "../sequence";
-import { svgText } from "../style";
+import { svgText, translationAminoAcidLabel } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface TranslationRowsProps {
@@ -253,10 +253,10 @@ class SingleNamedElement extends React.PureComponent<SingleNamedElementProps> {
                   data-testid="la-vz-translation"
                   dominantBaseline="middle"
                   id={aaId}
-                  style={svgText}
                   textAnchor="middle"
                   x={bpCount * 0.5 * charWidth}
                   y={`${h / 2 + 1}`}
+                  style={translationAminoAcidLabel}
                 >
                   {a}
                 </text>

--- a/src/Linear/Translations.tsx
+++ b/src/Linear/Translations.tsx
@@ -4,6 +4,7 @@ import { InputRefFunc } from "../SelectionHandler";
 import { borderColorByIndex, colorByIndex } from "../colors";
 import { SeqType, Translation } from "../elements";
 import { randomid } from "../sequence";
+import { svgText } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface TranslationRowsProps {
@@ -228,6 +229,7 @@ class TranslationRow extends React.PureComponent<TranslationRowProps> {
                   textAnchor="middle"
                   x={bpCount * 0.5 * charWidth}
                   y={`${h / 2 + 1}`}
+                  style={svgText}
                 >
                   {a}
                 </text>

--- a/src/Linear/Translations.tsx
+++ b/src/Linear/Translations.tsx
@@ -4,7 +4,7 @@ import { InputRefFunc } from "../SelectionHandler";
 import { borderColorByIndex, colorByIndex } from "../colors";
 import { SeqType, Translation } from "../elements";
 import { randomID } from "../sequence";
-import { svgText, translationAminoAcidLabel } from "../style";
+import { translationAminoAcidLabel } from "../style";
 import { FindXAndWidthType } from "./SeqBlock";
 
 interface TranslationRowsProps {
@@ -253,10 +253,10 @@ class SingleNamedElement extends React.PureComponent<SingleNamedElementProps> {
                   data-testid="la-vz-translation"
                   dominantBaseline="middle"
                   id={aaId}
+                  style={translationAminoAcidLabel}
                   textAnchor="middle"
                   x={bpCount * 0.5 * charWidth}
                   y={`${h / 2 + 1}`}
-                  style={translationAminoAcidLabel}
                 >
                   {a}
                 </text>

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -113,7 +113,7 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
    */
   setSelection = (selection: Selection) => {
     // If the user passed a selection, do not update our state here
-    const { parent, ref, ...rest } = selection;
+    const { parent: _, ref: __, ...rest } = selection;
     if (!this.props.selection) this.setState({ selection });
     if (this.props.onSelection) this.props.onSelection(rest);
   };
@@ -255,13 +255,13 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     return (
       <div
         ref={this.props.targetRef}
+        className="la-vz-viewer-container"
         data-testid="la-vz-viewer-container"
         style={{
           height: "100%",
           position: "relative",
           width: "100%",
         }}
-        className="la-vz-viewer-container"
       >
         <CentralIndexContext.Provider value={centralIndex}>
           <SelectionContext.Provider value={mergedSelection}>

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -230,7 +230,15 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     const circularProps = this.circularProps();
 
     return (
-      <div ref={this.props.targetRef} className="la-vz-viewer-container" data-testid="la-vz-viewer-container">
+      <div
+        ref={this.props.targetRef}
+        data-testid="la-vz-viewer-container"
+        style={{
+          height: "100%",
+          width: "100%",
+          position: "relative",
+        }}
+      >
         <CentralIndexContext.Provider value={centralIndex}>
           <SelectionContext.Provider value={this.getSelection(selection, selectionProp)}>
             <SelectionHandler

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -261,6 +261,7 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
           position: "relative",
           width: "100%",
         }}
+        className="la-vz-viewer-container"
       >
         <CentralIndexContext.Provider value={centralIndex}>
           <SelectionContext.Provider value={mergedSelection}>

--- a/src/SeqViz.css
+++ b/src/SeqViz.css
@@ -1,117 +1,12 @@
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500&display=swap");
 
-.la-vz-seqviz {
-}
-
-.la-vz-seqviz svg {
-}
-
-.la-vz-seqviz svg text {
-}
-
-.la-vz-seqviz svg text:selection {
-}
-
-.la-vz-viewer-container {
-}
-
-.la-vz-viewer-event-router {
-}
-
-.la-vz-search {
-}
-
-.la-vz-highlight {
-}
-
-.la-vz-selection {
-}
-
-.la-vz-selection-edge {
-}
-
-.la-vz-cut-site {
-}
-
-.la-vz-cut-site-highlight {
-}
-
-.la-vz-cut-site-text {
-}
-
-.la-vz-index-line {
-}
-
-.la-vz-index-tick {
-}
-
-.la-vz-index-tick-label {
-}
-
-.la-vz-annotation {
-  fill-opacity: 0.7;
-  shape-rendering: geometricPrecision;
-  stroke-width: 0.5;
-}
-
-.la-vz-annotation-label {
-  color: rgb(42, 42, 42);
-  font-weight: 400;
-  shape-rendering: geometricPrecision;
-  stroke-linejoin: round;
-  text-rendering: optimizeLegibility;
-}
-
-.la-vz-translation-amino-acid-label {
-  color: rgb(42, 42, 42);
-  font-size: 12px;
-  font-weight: 400;
-}
-
 /* Circular Viewer */
-.la-vz-viewer-circular {
-  cursor: text;
-  font-size: 12px;
-  font-weight: 300;
-  margin: auto;
-}
-
-.la-vz-circular-label {
-  cursor: pointer;
-}
 
 .la-vz-circular-label:hover {
   text-decoration: underline;
 }
 
-.la-vz-label-line {
-  fill: none;
-  stroke-width: 1;
-  stroke: rgb(158, 170, 184);
-}
-
 /* Linear Viewer */
-.la-vz-linear-scroller {
-  cursor: text;
-  font-weight: 300;
-  height: 100%;
-  outline: none !important;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  padding: 10px;
-  position: relative;
-}
-
-.la-vz-seqblock-container {
-  width: 100%;
-}
-
-.la-vz-seqblock {
-  width: 100%;
-  padding: 0;
-  /* this is for when very zoomed out and the bp index disappears beneath the next block */
-  overflow: visible;
-}
 
 .la-vz-scroll::-webkit-scrollbar {
   width: 7px;

--- a/src/SeqViz.css
+++ b/src/SeqViz.css
@@ -1,29 +1,5 @@
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500&display=swap");
 
-/* Circular Viewer */
-
 .la-vz-circular-label:hover {
   text-decoration: underline;
-}
-
-/* Linear Viewer */
-
-.la-vz-scroll::-webkit-scrollbar {
-  width: 7px;
-}
-
-.la-vz-scroll::-webkit-scrollbar-thumb {
-  background-clip: padding-box;
-  background-color: rgb(166, 166, 166);
-  border-radius: 7px;
-}
-
-.la-vz-scroll::-webkit-scrollbar-track {
-  border-radius: 20px;
-}
-
-.la-vz-scroll::-webkit-scrollbar-track-piece {
-  background-clip: padding-box;
-  background-color: rgb(236, 236, 236);
-  border-radius: 7px;
 }

--- a/src/SeqViz.css
+++ b/src/SeqViz.css
@@ -1,5 +1,0 @@
-@import url("https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500&display=swap");
-
-.la-vz-circular-label:hover {
-  text-decoration: underline;
-}

--- a/src/SeqViz.css
+++ b/src/SeqViz.css
@@ -1,102 +1,51 @@
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500&display=swap");
 
-/* Shared/common settings */
 .la-vz-seqviz {
-  height: 100%;
-  width: 100%;
 }
 
 .la-vz-seqviz svg {
-  overflow: visible !important;
 }
 
 .la-vz-seqviz svg text {
-  fill: rgb(42, 42, 42);
-  font-family: Roboto Mono, Monaco, monospace;
-  user-select: none;
-
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
 }
 
 .la-vz-seqviz svg text:selection {
-  background: none;
 }
 
 .la-vz-viewer-container {
-  height: 100%;
-  position: relative;
-  width: 100%;
 }
 
 .la-vz-viewer-event-router {
-  display: flex;
-  flex-direction: row;
-  height: 100%;
-  outline: none;
-  position: absolute;
-  width: 100%;
 }
 
 .la-vz-search {
-  fill: rgba(255, 251, 7, 0.5);
 }
 
 .la-vz-highlight {
-  fill: rgba(255, 251, 7, 0.25);
 }
 
 .la-vz-selection {
-  fill: rgb(222, 246, 255);
 }
 
 .la-vz-selection-edge {
-  fill: black;
-  stroke: black;
-  shape-rendering: geometricPrecision;
 }
 
 .la-vz-cut-site {
-  fill: transparent;
-  shape-rendering: auto;
-  stroke-width: 1;
-  stroke: rgb(115, 119, 125);
 }
 
 .la-vz-cut-site-highlight {
-  cursor: pointer;
-  fill: rgb(255, 251, 7);
-  fill-opacity: 0;
-  shape-rendering: auto;
-  stroke-width: 1;
-  stroke: rgb(115, 119, 125);
 }
 
 .la-vz-cut-site-text {
-  cursor: pointer;
-  font-size: 12px;
 }
 
 .la-vz-index-line {
-  fill: transparent;
-  shape-rendering: geometricPrecision;
-  stroke-width: 1;
-  stroke: rgb(115, 119, 125);
 }
 
 .la-vz-index-tick {
-  fill: transparent;
-  shape-rendering: geometricPrecision;
-  stroke-width: 1;
-  stroke: rgb(115, 119, 125);
 }
 
 .la-vz-index-tick-label {
-  fill: rgb(115, 119, 125);
-  font-weight: 300;
-  text-rendering: optimizeLegibility;
 }
 
 .la-vz-annotation {

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -424,7 +424,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
     };
 
     return (
-      <div className="la-vz-seqviz" data-testid="la-vz-seqviz" style={style}>
+      <div className="la-vz-seqviz" data-testid="la-vz-seqviz" style={{ height: "100%", width: "100%", ...style }}>
         <SeqViewerContainer {...this.props} {...props} {...this.state} />
       </div>
     );

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -209,6 +209,18 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
    * If an accession was provided, query it here.
    */
   componentDidMount(): void {
+    // Fetch Roboto Mono, the only font used by SeqViz (at the time of writing)
+    // https://github.com/typekit/webfontloader/issues/383#issuecomment-389627920
+    if (typeof window !== "undefined") {
+      /* eslint-disable */
+      require("webfontloader").load({
+        google: {
+          families: ["Roboto Mono:300,400,500"],
+        },
+      });
+    }
+
+    // Check if an accession was passed, we'll query it here if so
     const { accession } = this.props;
     if (!accession || !accession.length) {
       return;

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -74,12 +74,12 @@ export const borderColorByIndex = (i: number) => COLOR_BORDER_MAP[COLORS[i % COL
 const darkerColorCache = {};
 
 /** darken a HEX color by 50% */
-export const darkerColor = c => {
+export const darkerColor = (c: string): string => {
   if (darkerColorCache[c]) {
     return darkerColorCache[c];
   }
 
   const darkerColor = pSBC(-0.5, c);
   darkerColorCache[c] = darkerColor;
-  return darkerColor;
+  return darkerColor || c;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import { renderToString as reactRenderToString } from "react-dom/server";
 import Circular from "./Circular/Circular";
 import Linear from "./Linear/Linear";
 import SeqViz, { SeqVizProps } from "./SeqViz";
-import "./SeqViz.css";
 import enzymes from "./enzymes";
 
 /**

--- a/src/style.ts
+++ b/src/style.ts
@@ -30,7 +30,6 @@ export const selectionEdge: React.CSSProperties = {
   fill: "black",
   shapeRendering: "geometricPrecision",
   stroke: "black",
-  strokeWidth: 1,
 };
 
 export const cutSite: React.CSSProperties = {

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,0 +1,72 @@
+import * as React from "react";
+
+export const svgText: React.CSSProperties = {
+  fill: "rgb(42, 42, 42)",
+  fontFamily: "Roboto Mono, Monaco, monospace",
+  userSelect: "none",
+  WebkitUserSelect: "none",
+  MozUserSelect: "none",
+  msUserSelect: "none",
+  background: "none",
+};
+
+export const search: React.CSSProperties = {
+  fill: "rgba(255, 251, 7, 0.5)",
+  cursor: "pointer",
+};
+
+export const highlight: React.CSSProperties = {
+  fill: "rgba(255, 251, 7, 0.25)",
+  cursor: "pointer",
+  strokeWidth: 1,
+};
+
+export const selection: React.CSSProperties = {
+  fill: "rgb(222, 246, 255)",
+  shapeRendering: "auto",
+};
+
+export const selectionEdge: React.CSSProperties = {
+  fill: "black",
+  stroke: "black",
+  strokeWidth: 1,
+  shapeRendering: "geometricPrecision",
+};
+
+export const cutSite: React.CSSProperties = {
+  fill: "transparent",
+  shapeRendering: "auto",
+  strokeWidth: 1,
+  stroke: "rgb(115, 119, 125)",
+};
+
+export const cutSiteHighlight: React.CSSProperties = {
+  cursor: "pointer",
+  fill: "rgb(255, 251, 7)",
+  fillOpacity: 0,
+  shapeRendering: "auto",
+  strokeWidth: 1,
+  stroke: "rgb(115, 119, 125)",
+};
+
+export const indexLine: React.CSSProperties = {
+  fill: "transparent",
+  shapeRendering: "geometricPrecision",
+  strokeWidth: 1,
+  stroke: "rgb(115, 119, 125)",
+};
+
+export const indexTick: React.CSSProperties = {
+  fill: "transparent",
+  shapeRendering: "geometricPrecision",
+  strokeWidth: 1,
+  stroke: "rgb(115, 119, 125)",
+};
+
+export const indexTickLabel: React.CSSProperties = {
+  ...svgText,
+  fill: "rgb(115, 119, 125)",
+  fontWeight: 300,
+  textRendering: "optimizeLegibility",
+  fontSize: 12,
+};

--- a/src/style.ts
+++ b/src/style.ts
@@ -70,3 +70,65 @@ export const indexTickLabel: React.CSSProperties = {
   fontWeight: 300,
   textRendering: "optimizeLegibility",
 };
+
+export const annotation: React.CSSProperties = {
+  fillOpacity: 0.7,
+  shapeRendering: "geometricPrecision",
+  strokeWidth: 0.5,
+};
+
+export const annotationLabel: React.CSSProperties = {
+  ...svgText,
+  color: "rgb(42, 42, 42)",
+  fontWeight: 400,
+  shapeRendering: "geometricPrecision",
+  strokeLinejoin: "round",
+  textRendering: "optimizeLegibility",
+};
+
+export const translationAminoAcidLabel: React.CSSProperties = {
+  ...svgText,
+  color: "rgb(42, 42, 42)",
+  fontSize: 12,
+  fontWeight: 400,
+};
+
+export const viewerCircular: React.CSSProperties = {
+  cursor: "text",
+  fontSize: 12,
+  fontWeight: 300,
+  margin: "auto",
+};
+
+export const circularLabel: React.CSSProperties = {
+  ...svgText,
+  cursor: "pointer",
+};
+
+export const circularLabelHover: React.CSSProperties = {
+  ...circularLabel,
+  textDecoration: "underline",
+};
+
+export const circularLabelLine: React.CSSProperties = {
+  fill: "none",
+  strokeWidth: 1,
+  stroke: "rgb(158, 170, 184)",
+};
+
+export const linearScroller: React.CSSProperties = {
+  cursor: "text",
+  fontWeight: 300,
+  height: "100%",
+  outline: "none !important",
+  overflowX: "hidden",
+  overflowY: "scroll",
+  padding: 10,
+  position: "relative",
+};
+
+export const seqBlock: React.CSSProperties = {
+  width: "100%",
+  padding: 0,
+  overflow: "visible",
+};

--- a/src/style.ts
+++ b/src/style.ts
@@ -112,8 +112,8 @@ export const circularLabelHover: React.CSSProperties = {
 
 export const circularLabelLine: React.CSSProperties = {
   fill: "none",
-  strokeWidth: 1,
   stroke: "rgb(158, 170, 184)",
+  strokeWidth: 1,
 };
 
 export const linearScroller: React.CSSProperties = {
@@ -128,7 +128,7 @@ export const linearScroller: React.CSSProperties = {
 };
 
 export const seqBlock: React.CSSProperties = {
-  width: "100%",
-  padding: 0,
   overflow: "visible",
+  padding: 0,
+  width: "100%",
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,11 +15,6 @@ const cdnBuild = {
     rules: [
       { test: /\.(t|j)sx?$/, loader: "ts-loader", exclude: /node_modules/ },
       { test: /\.js$/, enforce: "pre", loader: "source-map-loader", exclude: /node_modules/ },
-      {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
-        exclude: /node_modules/,
-      },
     ],
   },
   optimization: {


### PR DESCRIPTION
closes https://github.com/Lattice-Automation/seqviz/issues/171

This gets rid of the .css file and all the style loaders that are causing window/self issues during SSR'ing of SeqViz (via Next, namely). This also picks up a related fix (for `self`) in `seqparse`: https://github.com/Lattice-Automation/seqparse/releases/tag/0.2.1

This moves all the CSS styles into boring TS objects that are imported and passed directly to the components like:

```
export const highlight: React.CSSProperties = {
  cursor: "pointer",
  fill: "rgba(255, 251, 7, 0.25)",
  strokeWidth: 1,
};

      <rect
        className="la-vz-highlight"
        style={highlight}
      />
```

In all cases I tried to leave the original `className` in case consumers were already overwriting style via those classnames