### PR TITLE
add custom children support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ By default, the circular viewer rotates when scrolling over the viewer. That can
 
 #### `Custom Rendering`
 
-This makes use of the `children`, `linearRef`, and `circularRef` props to allow custom rendering of the sequence viewers. For example, to render the linear viewer above the circular viewer:
+This makes use of the `children` and `refs` props to allow custom rendering of the sequence viewers. For example, to render the linear viewer above the circular viewer:
 
 ```jsx
 import { useRef } from "react";
@@ -308,8 +308,7 @@ export default () => {
     <SeqViz
       name="J23100"
       seq="TTGACGGCTAGCTCAGTCCTAGGTACAGTGCTAGC"
-      linearRef={linearRef}
-      curcularRef={circularRef}
+      refs={{circular: circularRef, linear: linearRef}}
     >
       {({ circularProps, linearProps, ...props }) => (
         <div

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ By default, the circular viewer rotates when scrolling over the viewer. That can
 
 #### `Custom Rendering`
 
-This makes use of the `children`, `linearRef` and `circularRef` props to allow custom rendering of the sequence viewers.  For example, you can do this to render the linear viewer above the circular viewer:
+This makes use of the `children`, `linearRef`, and `circularRef` props to allow custom rendering of the sequence viewers. For example, to render the linear viewer above the circular viewer:
 
 ```jsx
 import { useRef } from "react";
@@ -303,6 +303,7 @@ import { SeqViz, Linear, Circular } from "seqviz";
 export default () => {
   const linearRef = useRef();
   const circularRef = useRef();
+
   return (
     <SeqViz
       name="J23100"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export default () => (
 
 #### Non-React
 
-More details are in the [Viewer without React](#viewer-without-react) section.
+More details are in the [Viewer without React](#without-react) section.
 
 ```html
 <script>
@@ -291,6 +291,42 @@ Whether to show the complement sequence.
 #### `rotateOnScroll (=true)`
 
 By default, the circular viewer rotates when scrolling over the viewer. That can be disabled with rotateOnScroll: false.
+
+#### `Custom Rendering`
+
+This makes use of the `children`, `linearRef` and `circularRef` props to allow custom rendering of the sequence viewers.  For example, you can do this to render the linear viewer above the circular viewer:
+
+```jsx
+import { useRef } from "react";
+import { SeqViz, Linear, Circular } from "seqviz";
+
+export default () => {
+  const linearRef = useRef();
+  const circularRef = useRef();
+  return (
+    <SeqViz
+      name="J23100"
+      seq="TTGACGGCTAGCTCAGTCCTAGGTACAGTGCTAGC"
+      linearRef={linearRef}
+      curcularRef={circularRef}
+    >
+      {({ circularProps, linearProps, ...props }) => (
+        <div
+          style={{ display: "flex", flexDirection: "column", width: "100%" }}
+        >
+          <div ref={linearRef} style={{ height: "25%", width: "100%" }}>
+            <Linear {...linearProps} {...props} />
+          </div>
+          <div ref={circularRef} style={{ height: "75%", width: "100%" }}>
+            <Circular {...circularProps} {...props} />
+          </div>
+        </div>
+      )}
+    </SeqViz>
+  );
+};
+
+```
 
 ### Without React
 

--- a/demo/lib/App.tsx
+++ b/demo/lib/App.tsx
@@ -218,10 +218,9 @@ export default class App extends React.Component<any, AppState> {
                     // accession="MN623123"
                     key={`${this.state.viewer}${this.state.customChildren}`}
                     annotations={this.state.annotations}
-                    circularRef={this.circularRef}
                     enzymes={this.state.enzymes}
-                    linearRef={this.linearRef}
                     name={this.state.name}
+                    refs={{circular: this.circularRef, linear: this.linearRef}}
                     search={this.state.search}
                     selection={this.state.selection}
                     seq={this.state.seq}

--- a/demo/lib/App.tsx
+++ b/demo/lib/App.tsx
@@ -109,13 +109,13 @@ export default class App extends React.Component<any, AppState> {
       customChildren = ({ circularProps, linearProps, ...props }) => {
         if (this.state.viewer === "linear") {
           return  (
-              <div ref={this.linearRef} style={{ height: "70%", width: "100%" }}>
+              <div ref={this.linearRef} style={{ height: "100%", width: "100%" }}>
                 <Linear {...linearProps} {...props} />
               </div>
           );
         } else if (this.state.viewer === "circular") {
           return  (
-            <div ref={this.circularRef} style={{ height: "75%", width: "100%" }}>
+            <div ref={this.circularRef} style={{ height: "100%", width: "100%" }}>
               <Circular {...circularProps} {...props} />
             </div>
           );

--- a/src/Circular/Circular.tsx
+++ b/src/Circular/Circular.tsx
@@ -37,7 +37,7 @@ export type GenArcFunc = (args: {
   sweepFWD?: boolean;
 }) => string;
 
-interface CircularProps {
+export interface CircularProps {
   annotations: Annotation[];
   center: { x: number; y: number };
   compSeq: string;

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -20,24 +20,28 @@ export const CHAR_WIDTH = 7.2;
 export interface CustomChildrenProps {
   circularProps: Omit<CircularProps, "handleMouseEvent" | "inputRef" | "onUnmount">;
   handleMouseEvent: React.MouseEventHandler;
-  inputRef: InputRefFunc,
+  inputRef: InputRefFunc;
   linearProps: Omit<LinearProps, "handleMouseEvent" | "inputRef" | "onUnmount">;
   onUnmount: (ref: string) => void;
+}
+
+export interface SeqVizChildRefs {
+  circular?: React.RefObject<HTMLElement>;
+  linear?: React.RefObject<HTMLElement>;
 }
 
 interface SeqViewerContainerProps {
   annotations: Annotation[];
   bpColors: { [key: number | string]: string };
   children?: (props: CustomChildrenProps) => React.ReactNode;
-  circularRef?: React.RefObject<HTMLElement>;
   compSeq: string;
   copyEvent: (event: React.KeyboardEvent<HTMLElement>) => boolean;
   cutSites: CutSite[];
   height: number;
   highlights: Highlight[];
-  linearRef?: React.RefObject<HTMLElement>;
   name: string;
   onSelection: (selection: Selection) => void;
+  refs?: SeqVizChildRefs;
   rotateOnScroll: boolean;
   search: NameRange[];
   selection?: {
@@ -140,9 +144,9 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     const size = this.props.testSize || { height: this.props.height, width: this.props.width };
     const zoom = this.props.zoom.linear;
 
-    if (this.props.linearRef?.current && this.props.children) {
-      size.width = this.props.linearRef.current.clientWidth;
-      size.height = this.props.linearRef.current.clientHeight;
+    if (this.props.refs?.linear?.current && this.props.children) {
+      size.width = this.props.refs.linear.current.clientWidth;
+      size.height = this.props.refs.linear.current.clientHeight;
     } else if (viewer.includes("both")) {
       // hack
       size.width /= 2;
@@ -206,9 +210,9 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     const size = this.props.testSize || { height: this.props.height, width: this.props.width };
     const zoom = this.props.zoom.circular;
 
-    if (this.props.circularRef?.current) {
-      size.width = this.props.circularRef.current.clientWidth;
-      size.height = this.props.circularRef.current.clientHeight;
+    if (this.props.refs?.circular?.current) {
+      size.width = this.props.refs.circular.current.clientWidth;
+      size.height = this.props.refs.circular.current.clientHeight;
     } else if (viewer.includes("both")) {
       // hack
       size.width /= 2;
@@ -268,64 +272,67 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
                   seq={seq}
                   setSelection={this.setSelection}
                 >
-                  {this.props.children ? this.props.children({
-                    circularProps,
-                    handleMouseEvent,
-                    inputRef,
-                    linearProps,
-                    onUnmount,
-                  }) :
-                  <>
-                  {/* TODO: this sucks, some breaking refactor in future should get rid of it SeqViewer */}
-                  {viewer === "linear" && (
-                    <Linear
-                      {...linearProps}
-                      handleMouseEvent={handleMouseEvent}
-                      inputRef={inputRef}
-                      onUnmount={onUnmount}
-                    />
-                  )}
-                  {viewer === "circular" && (
-                    <Circular
-                      {...circularProps}
-                      handleMouseEvent={handleMouseEvent}
-                      inputRef={inputRef}
-                      onUnmount={onUnmount}
-                    />
-                  )}
-                  {viewer === "both" && (
+                  {this.props.children ? (
+                    this.props.children({
+                      circularProps,
+                      handleMouseEvent,
+                      inputRef,
+                      linearProps,
+                      onUnmount,
+                    })
+                  ) : (
                     <>
-                      <Circular
-                        {...circularProps}
-                        handleMouseEvent={handleMouseEvent}
-                        inputRef={inputRef}
-                        onUnmount={onUnmount}
-                      />
-                      <Linear
-                        {...linearProps}
-                        handleMouseEvent={handleMouseEvent}
-                        inputRef={inputRef}
-                        onUnmount={onUnmount}
-                      />
+                      {/* TODO: this sucks, some breaking refactor in future should get rid of it SeqViewer */}
+                      {viewer === "linear" && (
+                        <Linear
+                          {...linearProps}
+                          handleMouseEvent={handleMouseEvent}
+                          inputRef={inputRef}
+                          onUnmount={onUnmount}
+                        />
+                      )}
+                      {viewer === "circular" && (
+                        <Circular
+                          {...circularProps}
+                          handleMouseEvent={handleMouseEvent}
+                          inputRef={inputRef}
+                          onUnmount={onUnmount}
+                        />
+                      )}
+                      {viewer === "both" && (
+                        <>
+                          <Circular
+                            {...circularProps}
+                            handleMouseEvent={handleMouseEvent}
+                            inputRef={inputRef}
+                            onUnmount={onUnmount}
+                          />
+                          <Linear
+                            {...linearProps}
+                            handleMouseEvent={handleMouseEvent}
+                            inputRef={inputRef}
+                            onUnmount={onUnmount}
+                          />
+                        </>
+                      )}
+                      {viewer === "both_flip" && (
+                        <>
+                          <Linear
+                            {...linearProps}
+                            handleMouseEvent={handleMouseEvent}
+                            inputRef={inputRef}
+                            onUnmount={onUnmount}
+                          />
+                          <Circular
+                            {...circularProps}
+                            handleMouseEvent={handleMouseEvent}
+                            inputRef={inputRef}
+                            onUnmount={onUnmount}
+                          />
+                        </>
+                      )}
                     </>
                   )}
-                  {viewer === "both_flip" && (
-                    <>
-                      <Linear
-                        {...linearProps}
-                        handleMouseEvent={handleMouseEvent}
-                        inputRef={inputRef}
-                        onUnmount={onUnmount}
-                      />
-                      <Circular
-                        {...circularProps}
-                        handleMouseEvent={handleMouseEvent}
-                        inputRef={inputRef}
-                        onUnmount={onUnmount}
-                      />
-                    </>
-                  )}
-                  </>}
                 </EventHandler>
               )}
             </SelectionHandler>

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -42,6 +42,7 @@ export interface SeqVizProps {
   /** nucleotides keyed by symbol or index and the color to apply to it */
   bpColors?: { [key: number | string]: string };
 
+  /** Custom children to render within the SeqViz component. This is useful for when custom rendering the positioning of children viewers (Linear, Circular). */
   children?: (props: CustomChildrenProps) => React.ReactNode;
 
   /** Custom child circular viewer ref */

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import seqparse, { ParseOptions, parseFile } from "seqparse";
 
-import SeqViewerContainer from "./SeqViewerContainer";
+import SeqViewerContainer, { CustomChildrenProps } from "./SeqViewerContainer";
 import { COLORS, colorByIndex } from "./colors";
 import digest from "./digest";
 import {
@@ -42,6 +42,11 @@ export interface SeqVizProps {
   /** nucleotides keyed by symbol or index and the color to apply to it */
   bpColors?: { [key: number | string]: string };
 
+  children?: (props: CustomChildrenProps) => React.ReactNode;
+
+  /** Custom child circular viewer ref */
+  circularRef?: React.RefObject<HTMLElement>;
+
   /** a list of colors to populate un-colored annotations with. HEX, RGB, names are supported */
   colors?: string[];
 
@@ -79,6 +84,9 @@ export interface SeqVizProps {
 
   /** ranges of sequence to highlight on the viewer */
   highlights?: HighlightProp[];
+
+  /** Custom child linear viewer ref */
+  linearRef?: React.RefObject<HTMLElement>;
 
   /** the name of the sequence to show in the middle of the circular viewer */
   name?: string;

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import seqparse, { ParseOptions, parseFile } from "seqparse";
 
-import SeqViewerContainer, { CustomChildrenProps } from "./SeqViewerContainer";
+import SeqViewerContainer, { CustomChildrenProps, SeqVizChildRefs } from "./SeqViewerContainer";
 import { COLORS, colorByIndex } from "./colors";
 import digest from "./digest";
 import {
@@ -45,9 +45,6 @@ export interface SeqVizProps {
   /** Custom children to render within the SeqViz component. This is useful for when custom rendering the positioning of children viewers (Linear, Circular). */
   children?: (props: CustomChildrenProps) => React.ReactNode;
 
-  /** Custom child circular viewer ref */
-  circularRef?: React.RefObject<HTMLElement>;
-
   /** a list of colors to populate un-colored annotations with. HEX, RGB, names are supported */
   colors?: string[];
 
@@ -86,9 +83,6 @@ export interface SeqVizProps {
   /** ranges of sequence to highlight on the viewer */
   highlights?: HighlightProp[];
 
-  /** Custom child linear viewer ref */
-  linearRef?: React.RefObject<HTMLElement>;
-
   /** the name of the sequence to show in the middle of the circular viewer */
   name?: string;
 
@@ -97,6 +91,9 @@ export interface SeqVizProps {
 
   /** a callback that's executed on each click of the sequence viewer. Selection includes meta about the selected element */
   onSelection?: (selection: Selection) => void;
+
+  /** Refs associated with custom children. */
+  refs?: SeqVizChildRefs;
 
   /** whether the circular viewer should rotate when the mouse scrolls over the plasmid */
   rotateOnScroll?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,16 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { renderToString as reactRenderToString } from "react-dom/server";
 
+import Circular from "./Circular/Circular";
+import Linear from "./Linear/Linear";
 import SeqViz, { SeqVizProps } from "./SeqViz";
 import "./SeqViz.css";
 import enzymes from "./enzymes";
-
-import Linear from "./Linear/Linear";
-
-import Circular from "./Circular/Circular";
 
 /**
  * Export a React component directly for React-based development
  */
 export { SeqViz, Linear, Circular, enzymes as Enzymes };
-
-
 
 export default SeqViz;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,24 @@ import SeqViz, { SeqVizProps } from "./SeqViz";
 import "./SeqViz.css";
 import enzymes from "./enzymes";
 
+import Linear from "./Linear/Linear";
+
+import Circular from "./Circular/Circular";
+
 /**
  * Export a React component directly for React-based development
  */
-export { SeqViz, enzymes as Enzymes };
+export { SeqViz, Linear, Circular, enzymes as Enzymes };
+
+
 
 export default SeqViz;
 
 export type { SeqVizProps } from "./SeqViz";
+
+export type { CircularProps } from "./Circular/Circular";
+
+export type { LinearProps } from "./Linear/Linear";
 
 /**
  * Return a Viewer object with three properties:


### PR DESCRIPTION
This allows custom children to be defined instead of fixed hardcoded layouts (ie both/both_flipped)

<img width="1715" alt="Screenshot 2023-04-29 at 4 39 02 PM" src="https://user-images.githubusercontent.com/14841421/235328424-3f1ec210-3802-416e-8785-86bab1dea16f.png">

https://codesandbox.io/p/sandbox/bold-napier-ytln8u