### PR TITLE
selecting on circular viewer will scroll linear viewer

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,8 @@
     "deploy": "npm update seqviz && npm run build && aws s3 sync ./out s3://lattice-tools-s3/seqviz --delete && aws cloudfront create-invalidation --distribution-id E3NMX6D92LFTAV --paths '/seqviz/*'",
     "fix": "prettier ./lib/** ./pages/** --write && eslint lib --ext ts,tsx --fix",
     "lint": "prettier ./lib/** --check && eslint lib --ext ts,tsx --quiet",
-    "start": "open http://localhost:3010/ && next dev -p 3010"
+    "start": "open http://localhost:3010/ && next dev -p 3010",
+    "dev": "next dev -p 3010"
   },
   "dependencies": {
     "browserslist": "^4.21.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "minor": "./release.sh minor",
     "patch": "./release.sh patch",
     "start": "cd demo && npm run start",
+    "dev": "cd demo && npm install && npm run dev",
     "test": "CI=true jest"
   },
   "keywords": [

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -233,7 +233,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
    * Handle a sequence selection event on the circular viewer
    */
   handleCircularSeqEvent = (e: SeqVizMouseEvent) => {
-    const { seq } = this.props;
+    const { seq, setCentralIndex } = this.props;
     const selection = this.context;
 
     const { start } = selection;
@@ -249,6 +249,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
         : this.calcSelectionLength(selStart, currBase, true); // check clockwise selection length
       this.selectionStarted = lookahead > 0; // update check for whether there is a prior selection
       this.resetCircleDragVars(selStart); // begin drag event
+      setCentralIndex?.("LINEAR", selStart);
 
       this.setSelection({
         ...defaultSelection,


### PR DESCRIPTION
https://codesandbox.io/p/sandbox/seqviz-chu3r0

When you mousedown on circular viewer to make a selection, the linear viewer will automatically scroll to this position using centralIndex.

I did not add a scroll during mouseMove (dragging selection) because the UI would seem very busy with the scrolling.

The package.json changes are for codesandbox, so you can just do:
`https://githubbox.com/<user>/seqviz/tree/central_index` to get a fully working link
