### PR TITLE
hide complement in circular viewer when showComplement is turned off

### DIFF
--- a/src/Circular/Circular.tsx
+++ b/src/Circular/Circular.tsx
@@ -52,6 +52,7 @@ export interface CircularProps {
   rotateOnScroll: boolean;
   search: Range[];
   seq: string;
+  showComplement: boolean;
   showIndex: boolean;
   size: Size;
   yDiff: number;
@@ -309,8 +310,21 @@ export default class Circular extends React.Component<CircularProps, CircularSta
   };
 
   render() {
-    const { center, compSeq, cutSites, handleMouseEvent, inputRef, name, radius, search, seq, showIndex, size, yDiff } =
-      this.props;
+    const {
+      center,
+      compSeq,
+      cutSites,
+      handleMouseEvent,
+      inputRef,
+      name,
+      radius,
+      search,
+      seq,
+      showComplement,
+      showIndex,
+      size,
+      yDiff,
+    } = this.props;
     const { annotationsInRows, inlinedLabels, lineHeight, outerLabels, seqLength } = this.state;
 
     const { findCoor, genArc, getRotation, rotateCoor } = this;
@@ -356,6 +370,7 @@ export default class Circular extends React.Component<CircularProps, CircularSta
             compSeq={compSeq}
             name={name}
             seq={seq}
+            showComplement={showComplement}
             showIndex={showIndex}
             size={size}
             totalRows={totalRows}

--- a/src/Circular/Index.tsx
+++ b/src/Circular/Index.tsx
@@ -17,6 +17,7 @@ interface IndexProps {
   rotateCoor: (coor: Coor, degrees: number) => Coor;
   seq: string;
   seqLength: number;
+  showComplement: boolean;
   showIndex: boolean;
   size: Size;
   totalRows: number;
@@ -77,7 +78,7 @@ export class Index extends React.PureComponent<IndexProps> {
    * return a react element for the basepairs along the surface of the plasmid viewer
    */
   renderBasepairs = () => {
-    const { compSeq, findCoor, getRotation, lineHeight, radius, seq, seqLength } = this.props;
+    const { compSeq, findCoor, getRotation, lineHeight, radius, seq, seqLength, showComplement } = this.props;
     const { indexInc } = this.state;
     const centralIndex = this.context.circular;
 
@@ -102,17 +103,21 @@ export class Index extends React.PureComponent<IndexProps> {
           transform={getRotation(i)}
         >
           {seqForCircular.charAt(i)}
-        </text>,
-        <text
-          key={`la-vz-base-comp-${i}`}
-          {...findCoor(0, radius + lineHeight)}
-          dominantBaseline="middle"
-          style={svgText}
-          transform={getRotation(i)}
-        >
-          {compSeqForCircular.charAt(i)}
         </text>
       );
+      if (showComplement) {
+        basepairsToRender.push(
+          <text
+            key={`la-vz-base-comp-${i}`}
+            {...findCoor(0, radius + lineHeight)}
+            dominantBaseline="middle"
+            style={svgText}
+            transform={getRotation(i)}
+          >
+            {compSeqForCircular.charAt(i)}
+          </text>
+        );
+      }
     }
     return basepairsToRender;
   };


### PR DESCRIPTION
If showComplement=false for Circular viewer, don't show complement sequence.

https://codesandbox.io/p/sandbox/small-rgb-9f2mfs
