### PR TITLE
Configuration option to disable loading fonts from Google Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ By default, the circular viewer rotates when scrolling over the viewer. That can
 
 See: [custom viewer positioning](#custom-viewer-positioning)
 
+#### `useExternalFonts (=true)`
+
+Whether to allow font loading from external sources. (Google Fonts)
+
+If set to false, fonts must be provided manually.
+
 ### Custom Viewer Positioning
 
 This makes use of the `children` and `refs` props to allow custom rendering of the sequence viewers. For example, to render the linear viewer above the circular viewer:

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -142,6 +142,12 @@ export interface SeqVizProps {
   /** ranges of sequence that should have amino acid translations shown */
   translations?: { direction?: number; end: number; start: number }[];
 
+  /**
+   * If false, SeqViz will not attempt to download fonts from external sites.
+   */
+  useExternalFonts?: boolean;
+
+
   /** the orientation of the viewer(s). "both", the default, has a circular viewer on left and a linear viewer on right. */
   viewer?: "linear" | "circular" | "both" | "both_flip";
 
@@ -194,6 +200,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
     showIndex: true,
     style: {},
     translations: [],
+    useExternalFonts: true,
     viewer: "both",
     zoom: { circular: 0, linear: 50 },
   };
@@ -213,15 +220,22 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
    * If an accession was provided, query it here.
    */
   componentDidMount(): void {
-    // Fetch Roboto Mono, the only font used by SeqViz (at the time of writing)
-    // https://github.com/typekit/webfontloader/issues/383#issuecomment-389627920
     if (typeof window !== "undefined") {
-      /* eslint-disable */
-      require("webfontloader").load({
-        google: {
-          families: ["Roboto Mono:300,400,500"],
-        },
-      });
+      // Allow the user to choose weather to load fonts from Google Fonts or from another source
+      if (this.props.useExternalFonts) {
+        // Fetch Roboto Mono, the only font used by SeqViz (at the time of writing)
+        // https://github.com/typekit/webfontloader/issues/383#issuecomment-389627920
+        /* eslint-disable */
+        require("webfontloader").load({
+          google: {
+            families: ["Roboto Mono:300,400,500"],
+          },
+        });
+      } else {
+        if (!document.fonts.check("Roboto Mono")) {
+          console.warn("SeqViz: Use external fonts disabled but Roboto Mono not available!")
+        }
+      }
     }
 
     // Check if an accession was passed, we'll query it here if so

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -221,7 +221,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
    */
   componentDidMount(): void {
     if (typeof window !== "undefined") {
-      // Allow the user to choose weather to load fonts from Google Fonts or from another source
+      // Allow the user to choose whether to load fonts from Google Fonts or from another source
       if (this.props.useExternalFonts) {
         // Fetch Roboto Mono, the only font used by SeqViz (at the time of writing)
         // https://github.com/typekit/webfontloader/issues/383#issuecomment-389627920

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -147,7 +147,6 @@ export interface SeqVizProps {
    */
   useExternalFonts?: boolean;
 
-
   /** the orientation of the viewer(s). "both", the default, has a circular viewer on left and a linear viewer on right. */
   viewer?: "linear" | "circular" | "both" | "both_flip";
 

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -231,10 +231,6 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
             families: ["Roboto Mono:300,400,500"],
           },
         });
-      } else {
-        if (!document.fonts.check("Roboto Mono")) {
-          console.warn("SeqViz: Use external fonts disabled but Roboto Mono not available!")
-        }
       }
     }
 


### PR DESCRIPTION
Hi,

We are developing a team wiki for our [iGEM](igem.org) team this year. However, team wikis are not permitted to access external resources, such as Google Fonts. To mitigate this we have added an optional configuration option that disabled font loading from Google Fonts, allowing the developer to provide the fonts manually (in this case hosted on iGEM servers)

I think this would be beneficial to upstream for the benefit of others encountering this use-case (especially within the competition in the following years)

Thanks,

James