### PR TITLE
Ellipsize annotation if it doesn't fit in Linear view

### DIFF
--- a/src/Linear/Annotations.tsx
+++ b/src/Linear/Annotations.tsx
@@ -182,12 +182,24 @@ const SingleNamedElement = (props: {
     }
   }
 
-  // determine whether the element name fits within the width of the element
-  const nameLength = name.length * 6.75; // aspect ratio of roboto mono is ~0.66
-  const nameFits = nameLength < width - 15;
+  // 0.591 is our best approximation of Roboto Mono's aspect ratio (width / height).
+  const annotationCharacterWidth = 0.591 * 12;
+  const availableCharacters = Math.floor((width - 30) / annotationCharacterWidth);
+  // Ellipsize the name if it's too long.
+  let displayName;
+  if (name.length <= availableCharacters) {
+    displayName = name;
+  } else if (availableCharacters <= 3) {
+    // If there's only room for 3 characters, we can't ellipsize.
+    displayName = "";
+  } else {
+    displayName = `${name.slice(0, availableCharacters - 3)}...`;
+  }
 
   return (
     <g id={element.id} transform={`translate(${x}, ${0.1 * height})`}>
+      {/* <title> provides a hover tooltip on most browsers */}
+      <title>{name}</title>
       <path
         ref={inputRef(element.id, {
           end: end,
@@ -213,30 +225,27 @@ const SingleNamedElement = (props: {
         onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
         onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
       />
-
-      {nameFits && (
-        <text
-          className="la-vz-annotation-label"
-          cursor="pointer"
-          dominantBaseline="middle"
-          fontSize={12}
-          id={element.id}
-          style={annotationLabel}
-          textAnchor="middle"
-          x={width / 2}
-          y={height / 2 + 1}
-          onBlur={() => {
-            // do nothing
-          }}
-          onFocus={() => {
-            // do nothing
-          }}
-          onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
-          onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
-        >
-          {name}
-        </text>
-      )}
+      <text
+        className="la-vz-annotation-label"
+        cursor="pointer"
+        dominantBaseline="middle"
+        fontSize={12}
+        id={element.id}
+        style={annotationLabel}
+        textAnchor="middle"
+        x={width / 2}
+        y={height / 2 + 1}
+        onBlur={() => {
+          // do nothing
+        }}
+        onFocus={() => {
+          // do nothing
+        }}
+        onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
+        onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
+      >
+        {displayName}
+      </text>
     </g>
   );
 };

--- a/src/Linear/Annotations.tsx
+++ b/src/Linear/Annotations.tsx
@@ -184,16 +184,19 @@ const SingleNamedElement = (props: {
 
   // 0.591 is our best approximation of Roboto Mono's aspect ratio (width / height).
   const annotationCharacterWidth = 0.591 * 12;
-  const availableCharacters = Math.floor((width - 30) / annotationCharacterWidth);
-  // Ellipsize the name if it's too long.
+  const availableCharacters = Math.floor((width - 40) / annotationCharacterWidth);
+  // Ellipsize or hide the name if it's too long.
   let displayName;
   if (name.length <= availableCharacters) {
     displayName = name;
-  } else if (availableCharacters <= 3) {
-    // If there's only room for 3 characters, we can't ellipsize.
-    displayName = "";
   } else {
-    displayName = `${name.slice(0, availableCharacters - 3)}...`;
+    const charactersToShow = availableCharacters - 1;
+    if (charactersToShow < 3) {
+      // If we can't show at least three characters, don't show any.
+      displayName = "";
+    } else {
+      displayName = `${name.slice(0, charactersToShow)}…`;
+    }
   }
 
   return (


### PR DESCRIPTION
This PR changes the default annotation behavior when the annotation name is too long to fit within the element. Instead of not displaying the name at all, we now truncate the name and display the truncated version.

Bundled are a few other related tweaks:

- If there's not room for the ellipsized version, we fall back to the old behavior of displaying no annotation
- In order to further increase readability, we add a hover tooltip showing the full name via the SVG `<title>` element
- This increases the estimated aspect ratio of Roboto Mono to be more in line with what it seems to be in practice. Previously, the text would increasingly run into the edges of the box as the annotation got longer, which suggested that our aspect ratio estimate was a little low.

Demo: https://www.loom.com/share/e3deaa5a2c4241a392f63df453049b61