### PR TITLE
Introduce a Primer element

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ annotations = [
 
 In the example above, the "Strong promoter" would span the first to twenty-second base pair.
 
+#### `primers (=[])`
+
+An array of `Primer`s to render. Each `Primer` requires 0-based start (inclusive) and end (exclusive) indexes. `name`s are rendered on top of the annotations. Set the primer's direction to `1` for forward primer and `-1` for reverse primer.
+
+```js
+primers = [
+  { start: 33, end: 53, name: "LacZ Foward Primer", direction: 1 },
+  { id: "18fbd562-9f87-4a17-aa20-b8448538cbe6", start: 3098, end: 3128, name: "LacZ Reverse Primer", direction: -1, color: "#FAA887" },
+];
+```
+
+In the example above, the foward and reverse primers of LacZ are define by the direction parameter. Notice that id and color could be optionally used.
+
 #### `translations (=[])`
 
 An array of `translations`: sequence ranges to translate and render as amino acids sequences. Requires 0-based `start` (inclusive) and `end` (exclusive) indexes relative the DNA sequence. A direction is required: `1` (FWD) or `-1` (REV).

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ primers = [
 ];
 ```
 
-In the example above, the foward and reverse primers of LacZ are define by the direction parameter. Notice that id and color could be optionally used.
+In the example above, the forward and reverse primers of LacZ are define by the direction parameter. Notice that color could be used optionally.
 
 #### `translations (=[])`
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ In the example above, the "Strong promoter" would span the first to twenty-secon
 
 #### `primers (=[])`
 
-An array of `Primer`s to render. Each `Primer` requires 0-based start (inclusive) and end (exclusive) indexes. `name`s are rendered on top of the annotations. Set the primer's direction to `1` for forward primer and `-1` for reverse primer.
+An array of `Primer`s to render. Each `Primer` requires 0-based start (inclusive) and end (exclusive) indexes. `name`s are rendered on top of the primers. Set the primer's direction to `1` for forward primer and `-1` for reverse primer.
 
 ```js
 primers = [
   { start: 33, end: 53, name: "LacZ Foward Primer", direction: 1 },
-  { id: "18fbd562-9f87-4a17-aa20-b8448538cbe6", start: 3098, end: 3128, name: "LacZ Reverse Primer", direction: -1, color: "#FAA887" },
+  { start: 3098, end: 3128, name: "LacZ Reverse Primer", direction: -1, color: "#FAA887" },
 ];
 ```
 

--- a/demo/lib/App.tsx
+++ b/demo/lib/App.tsx
@@ -17,9 +17,11 @@ import seqparse from "seqparse";
 import Circular from "../../src/Circular/Circular";
 import Linear from "../../src/Linear/Linear";
 import SeqViz from "../../src/SeqViz";
-import { AnnotationProp } from "../../src/elements";
+import { AnnotationProp, Primer } from "../../src/elements";
 import Header from "./Header";
 import file from "./file";
+import { Direction } from "../../src/Linear/Primers";
+import { COLORS, chooseRandomColor } from "../../src/colors";
 
 const viewerTypeOptions = [
   { key: "both", text: "Both", value: "both" },
@@ -33,6 +35,7 @@ interface AppState {
   customChildren: boolean;
   enzymes: any[];
   name: string;
+  primers: Primer[]
   search: { query: string };
   searchResults: any;
   selection: any;
@@ -52,6 +55,24 @@ export default class App extends React.Component<any, AppState> {
     customChildren: true,
     enzymes: ["PstI", "EcoRI", "XbaI", "SpeI"],
     name: "",
+    primers: [
+      {
+        color: chooseRandomColor(),
+        direction: Direction.FOWARD,
+        end: 653,
+        id: "527923581",
+        name: "pLtetO-1 fw primer",
+        start: 633,
+      }, 
+      {
+        color: chooseRandomColor(),
+        direction: Direction.REVERSE,
+        end: 706,
+        id: "527923582",
+        name: "pLtetO-1 rev primer",
+        start: 686,
+      }, 
+    ],
     search: { query: "ttnnnaat" },
     searchResults: {},
     selection: {},
@@ -73,6 +94,7 @@ export default class App extends React.Component<any, AppState> {
 
   componentDidMount = async () => {
     const seq = await seqparse(file);
+
     this.setState({ annotations: seq.annotations, name: seq.name, seq: seq.seq });
   };
 
@@ -215,6 +237,7 @@ export default class App extends React.Component<any, AppState> {
                     // accession="MN623123"
                     key={`${this.state.viewer}${this.state.customChildren}`}
                     annotations={this.state.annotations}
+                    primers={this.state.primers}
                     enzymes={this.state.enzymes}
                     highlights={[{ start: 0, end: 10 }]}
                     name={this.state.name}

--- a/demo/lib/App.tsx
+++ b/demo/lib/App.tsx
@@ -17,11 +17,10 @@ import seqparse from "seqparse";
 import Circular from "../../src/Circular/Circular";
 import Linear from "../../src/Linear/Linear";
 import SeqViz from "../../src/SeqViz";
+import { chooseRandomColor } from "../../src/colors";
 import { AnnotationProp, Primer } from "../../src/elements";
 import Header from "./Header";
 import file from "./file";
-import { Direction } from "../../src/Linear/Primers";
-import { COLORS, chooseRandomColor } from "../../src/colors";
 
 const viewerTypeOptions = [
   { key: "both", text: "Both", value: "both" },
@@ -35,7 +34,7 @@ interface AppState {
   customChildren: boolean;
   enzymes: any[];
   name: string;
-  primers: Primer[]
+  primers: Primer[];
   search: { query: string };
   searchResults: any;
   selection: any;
@@ -58,20 +57,44 @@ export default class App extends React.Component<any, AppState> {
     primers: [
       {
         color: chooseRandomColor(),
-        direction: Direction.FOWARD,
+        direction: 1,
         end: 653,
         id: "527923581",
         name: "pLtetO-1 fw primer",
         start: 633,
-      }, 
+      },
       {
         color: chooseRandomColor(),
-        direction: Direction.REVERSE,
+        direction: -1,
         end: 706,
-        id: "527923582",
+        id: "5279asdf582",
         name: "pLtetO-1 rev primer",
         start: 686,
-      }, 
+      },
+      {
+        color: chooseRandomColor(),
+        direction: 1,
+        end: 535,
+        id: "5279fd582",
+        name: "pLtetO-1 fwd primer",
+        start: 512,
+      },
+      {
+        color: chooseRandomColor(),
+        direction: -1,
+        end: 535,
+        id: "527923dfd582",
+        name: "pLtetO-1 rev primer",
+        start: 512,
+      },
+      {
+        color: chooseRandomColor(),
+        direction: -1,
+        end: 535,
+        id: "52792saf3582",
+        name: "pLtetO-1 rev primer",
+        start: 512,
+      },
     ],
     search: { query: "ttnnnaat" },
     searchResults: {},

--- a/src/Linear/Primers.tsx
+++ b/src/Linear/Primers.tsx
@@ -1,0 +1,268 @@
+
+import * as React from "react";
+
+import { InputRefFunc } from "../SelectionHandler";
+import { COLOR_BORDER_MAP, darkerColor } from "../colors";
+import { NameRange } from "../elements";
+import { annotation, annotationLabel } from "../style";
+import { FindXAndWidthElementType } from "./SeqBlock";
+
+const hoverOtherAnnotationRows = (className: string, opacity: number) => {
+  if (!document) return;
+  const elements = document.getElementsByClassName(className) as HTMLCollectionOf<HTMLElement>;
+  for (let i = 0; i < elements.length; i += 1) {
+    elements[i].style.fillOpacity = `${opacity}`;
+  }
+};
+
+export enum Direction {
+  FOWARD = 1,
+  REVERSE = -1
+}
+/**
+ * Render each row of annotations into its own row.
+ * This is not a default export for sake of the React component displayName.
+ */
+const PrimeRows = (props: {
+  primerRows: NameRange[][];
+  direction: Direction
+  bpsPerBlock: number;
+  elementHeight: number;
+  findXAndWidth: FindXAndWidthElementType;
+  firstBase: number;
+  fullSeq: string;
+  inputRef: InputRefFunc;
+  lastBase: number;
+  seqBlockRef: unknown;
+  width: number;
+  yDiff: number;
+}) => (
+  <g>
+    {props.primerRows.map((primers: NameRange[], i: number) => (
+      <PrimerRow
+        key={`annotation-linear-row-${primers[0].id}-${props.firstBase}-${props.lastBase}`}
+        primers={primers}
+        direction={props.direction}
+        bpsPerBlock={props.bpsPerBlock}
+        findXAndWidth={props.findXAndWidth}
+        firstBase={props.firstBase}
+        fullSeq={props.fullSeq}
+        height={props.elementHeight}
+        inputRef={props.inputRef}
+        lastBase={props.lastBase}
+        seqBlockRef={props.seqBlockRef}
+        width={props.width}
+        y={props.yDiff + props.elementHeight * i}
+      />
+    ))}
+  </g>
+);
+
+export default PrimeRows;
+
+/**
+ * A single row of annotations. Multiple of these may be in one seqBlock
+ * vertically stacked on top of one another in non-overlapping arrays.
+ */
+const PrimerRow = (props: {
+  primers: NameRange[];
+  direction: Direction;
+  bpsPerBlock: number;
+  findXAndWidth: FindXAndWidthElementType;
+  firstBase: number;
+  fullSeq: string;
+  height: number;
+  inputRef: InputRefFunc;
+  lastBase: number;
+  seqBlockRef: unknown;
+  width: number;
+  y: number;
+}) => {
+  return (
+    <g
+      className="la-vz-linear-annotation-row"
+      height={props.height * 0.8}
+      transform={`translate(0, ${props.y})`}
+      width={props.width}
+    >
+      {props.primers.filter((a) => a.direction == props.direction).map((a, i) => (
+                <SingleNamedElement
+                  {...props} // include overflowLeft in the key to avoid two split annotations in the same row from sharing a key
+                  key={`annotation-linear-${a.id}-${i}-${props.firstBase}-${props.lastBase}`}
+                  element={a}
+                  elements={props.primers}
+                  index={i}
+                />
+              )
+      )}
+    </g>
+  );
+} 
+/**
+ * SingleNamedElement is a single rectangular element in the SeqBlock.
+ * It does a bunch of stuff to avoid edge-cases from wrapping around the 0-index, edge of blocks, etc.
+ */
+const SingleNamedElement = (props: {
+  element: NameRange;
+  elements: NameRange[];
+  findXAndWidth: FindXAndWidthElementType;
+  firstBase: number;
+  height: number;
+  index: number;
+  inputRef: InputRefFunc;
+  lastBase: number;
+}) => {
+  const { element, elements, findXAndWidth, firstBase, index, inputRef, lastBase } = props;
+
+  const { color, direction, end, name, start } = element;
+  const forward = direction === Direction.FOWARD;
+  const reverse = direction === Direction.REVERSE;
+  const { overflowLeft, overflowRight, width, x: origX } = findXAndWidth(index, element, elements);
+  const crossZero = start > end && end < firstBase;
+
+  // does the element begin or end within this seqBlock with a directionality?
+  const endFWD = forward && end > firstBase && end <= lastBase;
+  const endREV = reverse && start >= firstBase && start <= lastBase;
+
+  // create padding on either side, vertically, of an element
+  const height = props.height * 0.8;
+
+  const cW = 4; // jagged cutoff width
+  const cH = height / 4; // jagged cutoff height
+  const [x, w] = [origX, width];
+
+  // create the SVG path, starting at the topLeft and working clockwise
+  // there is additional logic here for if the element overflows
+  // to the left or right of this seqBlock, where a "jagged edge" is created
+  const topLeft = "M 0 0";
+  let topRight = endFWD ? 
+    `
+      L ${width - Math.min(8 * cW, w)} 0
+      L ${width - Math.min(8 * cW, w)} ${-1 * height}
+    ` :
+    `L ${width} 0`;
+
+  let linePath = "";
+
+  let bottomRight = `L ${width} ${height}`; // flat right edge
+  if ((overflowRight && width > 2 * cW) || crossZero) {
+    bottomRight = `
+        L ${width - cW} ${cH}
+        L ${width} ${2 * cH}
+        L ${width - cW} ${3 * cH}
+        L ${width} ${4 * cH}`; // jagged right edge
+  } else if (endFWD) {
+    bottomRight = `
+        L ${width} ${height}`; // arrow forward
+  }
+
+  let bottomLeft = `L 0 ${height} L 0 0`; // flat left edge
+  if (overflowLeft && width > 2 * cW) {
+    bottomLeft = `
+        L 0 ${height}
+        L ${cW} ${3 * cH}
+        L 0 ${2 * cH}
+        L ${cW} ${cH}
+        L 0 0`; // jagged left edge
+  } else if (endREV) {
+    bottomLeft = `
+        L ${Math.min(8 * cW, w)} ${height}
+        L ${Math.min(8 * cW, w)} ${height * 2}`; // arrow reverse
+  }
+
+  linePath = `${topLeft} ${topRight} ${bottomRight} ${bottomLeft}`;
+
+  if ((forward && overflowRight) || (forward && crossZero)) {
+    // If it's less than 15 pixels the double arrow barely fits
+    if (width > 15) {
+      linePath += `
+        M ${width - 3 * cW} ${cH}
+        L ${width - 2 * cW} ${2 * cH}
+        L ${width - 3 * cW} ${3 * cH}
+        M ${width - 4 * cW} ${cH}
+        L ${width - 3 * cW} ${2 * cH}
+        L ${width - 4 * cW} ${3 * cH}`; // add double arrow forward
+    }
+  }
+  if ((reverse && overflowLeft) || (reverse && crossZero)) {
+    // If it's less than 15 pixels the double arrow barely fits
+    if (width > 15) {
+      linePath += `
+        M ${3 * cW} ${3 * cH}
+        L ${2 * cW} ${cH * 2}
+        L ${3 * cW} ${cH}
+        M ${4 * cW} ${3 * cH}
+        L ${3 * cW} ${cH * 2}
+        L ${4 * cW} ${cH}`; // add double forward reverse
+    }
+  }
+  // 0.591 is our best approximation of Roboto Mono's aspect ratio (width / height).
+  const fontSize = 12;
+  const annotationCharacterWidth = 0.591 * fontSize;
+  const availableCharacters = Math.floor((width - 40) / annotationCharacterWidth);
+
+  // Ellipsize or hide the name if it's too long.
+  let displayName = name;
+  if (name.length > availableCharacters) {
+    const charactersToShow = availableCharacters - 1;
+    if (charactersToShow < 3) {
+      // If we can't show at least three characters, don't show any.
+      displayName = "";
+    } else {
+      displayName = `${name.slice(0, charactersToShow)}…`;
+    }
+  }
+
+  return (
+    <g id={element.id} transform={`translate(${x}, ${0.1 * height})`}>
+      {/* <title> provides a hover tooltip on most browsers */}
+      <title>{name}</title>
+      <path
+        ref={inputRef(element.id, {
+          end: end,
+          name: element.name,
+          ref: element.id,
+          start: start,
+          type: "ANNOTATION",
+          viewer: "LINEAR",
+        })}
+        className={`${element.id} la-vz-annotation`}
+        cursor="pointer"
+        d={linePath}
+        fill={color}
+        id={element.id}
+        stroke={color ? COLOR_BORDER_MAP[color] || darkerColor(color) : "gray"}
+        style={annotation}
+        onBlur={() => {
+          // do nothing
+        }}
+        onFocus={() => {
+          // do nothing
+        }}
+        onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
+        onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
+      />
+      <text
+        className="la-vz-annotation-label"
+        cursor="pointer"
+        dominantBaseline="middle"
+        fontSize={fontSize}
+        id={element.id}
+        style={annotationLabel}
+        textAnchor="middle"
+        x={width / 2}
+        y={height / 2 + 1}
+        onBlur={() => {
+          // do nothing
+        }}
+        onFocus={() => {
+          // do nothing
+        }}
+        onMouseOut={() => hoverOtherAnnotationRows(element.id, 0.7)}
+        onMouseOver={() => hoverOtherAnnotationRows(element.id, 1.0)}
+      >
+        {displayName}
+      </text>
+    </g>
+  );
+};

--- a/src/Linear/Primers.tsx
+++ b/src/Linear/Primers.tsx
@@ -35,7 +35,7 @@ const PrimeRows = (props: {
   <g>
     {props.primerRows.map((primers: NameRange[], i: number) => (
       <PrimerRow
-        key={`annotation-linear-row-${primers[0].id}-${props.firstBase}-${props.lastBase}`}
+        key={`primer-linear-row-${primers[0].id}-${props.firstBase}-${props.lastBase}`}
         bpsPerBlock={props.bpsPerBlock}
         direction={props.direction}
         findXAndWidth={props.findXAndWidth}
@@ -75,7 +75,7 @@ const PrimerRow = (props: {
 }) => {
   return (
     <g
-      className="la-vz-linear-annotation-row"
+      className="la-vz-linear-primer-row"
       height={props.height * 0.8}
       transform={`translate(0, ${props.y})`}
       width={props.width}
@@ -84,8 +84,8 @@ const PrimerRow = (props: {
         .filter(a => a.direction == props.direction)
         .map((a, i) => (
           <SingleNamedElement
-            {...props} // include overflowLeft in the key to avoid two split annotations in the same row from sharing a key
-            key={`annotation-linear-${a.id}-${i}-${props.firstBase}-${props.lastBase}`}
+            {...props} // include overflowLeft in the key to avoid two split primers in the same row from sharing a key
+            key={`primer-linear-${a.id}-${i}-${props.firstBase}-${props.lastBase}`}
             element={a}
             elements={props.primers}
             index={i}
@@ -94,6 +94,7 @@ const PrimerRow = (props: {
     </g>
   );
 };
+
 /**
  * SingleNamedElement is a single rectangular element in the SeqBlock.
  * It does a bunch of stuff to avoid edge-cases from wrapping around the 0-index, edge of blocks, etc.

--- a/src/Linear/SeqBlock.test.tsx
+++ b/src/Linear/SeqBlock.test.tsx
@@ -30,9 +30,9 @@ const defaultProps = {
   onUnmount: () => {
     // do nothing
   },
-  primers: [],
   primerFwdRows: [],
   primerRevRows: [],
+  primers: [],
   searchRows: [],
   selection: {},
   seqFontSize: 12,

--- a/src/Linear/SeqBlock.test.tsx
+++ b/src/Linear/SeqBlock.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 
 import * as React from "react";
 
+import { SeqType } from "../elements";
 import { SeqBlock } from "./SeqBlock";
 
 const defaultProps = {
@@ -13,6 +14,7 @@ const defaultProps = {
   elementHeight: 16,
   firstBase: 0,
   forwardPrimerRows: [],
+  handleMouseEvent: () => {},
   highlightedRegions: [],
   highlights: [],
   id: "",
@@ -28,10 +30,13 @@ const defaultProps = {
   onUnmount: () => {
     // do nothing
   },
-  reversePrimerRows: [],
+  primers: [],
+  primerFwdRows: [],
+  primerRevRows: [],
   searchRows: [],
   selection: {},
   seqFontSize: 12,
+  seqType: "dna" as SeqType,
   showComplement: true,
   showIndex: true,
   size: { height: 600, width: 1200 },
@@ -52,7 +57,6 @@ describe("SeqBlock", () => {
   it("renders with a single block", async () => {
     const seq = "gcgaaaaatcaataaggaggcaacaagatgtgcgaaaaacatcttaatcatgcggtggagggtttctaatg";
     render(
-      // @ts-ignore
       <SeqBlock
         {...defaultProps}
         annotationRows={[

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -135,6 +135,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
       case "FIND":
       case "TRANSLATION":
       case "ENZYME":
+      case "PRIMER":
       case "HIGHLIGHT": {
         if (viewer !== "LINEAR" && setCentralIndex) {
           // if an element was clicked on the circular viewer, scroll the linear

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -6,7 +6,7 @@ import { EventHandler } from "./EventHandler";
 import Linear, { LinearProps } from "./Linear/Linear";
 import SelectionHandler, { InputRefFunc } from "./SelectionHandler";
 import CentralIndexContext from "./centralIndexContext";
-import { Annotation, CutSite, Highlight, NameRange, Range, SeqType } from "./elements";
+import { Annotation, CutSite, Highlight, NameRange, Primer, Range, SeqType } from "./elements";
 import { isEqual } from "./isEqual";
 import SelectionContext, { Selection, defaultSelection } from "./selectionContext";
 
@@ -41,6 +41,7 @@ interface SeqViewerContainerProps {
   highlights: Highlight[];
   name: string;
   onSelection: (selection: Selection) => void;
+  primers: Primer[];
   refs?: SeqVizChildRefs;
   rotateOnScroll: boolean;
   search: NameRange[];

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -12,6 +12,7 @@ import {
   Highlight,
   HighlightProp,
   NameRange,
+  PrimerProp,
   Range,
   SeqType,
 } from "./elements";
@@ -97,6 +98,9 @@ export interface SeqVizProps {
 
   /** a callback that's executed on each click of the sequence viewer. Selection includes meta about the selected element */
   onSelection?: (selection: Selection) => void;
+
+  /** a list of primers to render above or below the sequences. At the time of writing, only the Linear viewer is supported. */
+  primers: PrimerProp[];
 
   /** Refs associated with custom children. */
   refs?: SeqVizChildRefs;
@@ -193,6 +197,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
     name: "",
     onSearch: (_: Range[]) => null,
     onSelection: (_: Selection) => null,
+    primers: [],
     rotateOnScroll: true,
     search: { mismatch: 0, query: "" },
     selectAllEvent: e => e.key === "a" && (e.metaKey || e.ctrlKey),
@@ -412,7 +417,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
     }));
 
   render() {
-    const { highlightedRegions, highlights, showComplement, showIndex, style, zoom } = this.props;
+    const { highlightedRegions, highlights, primers, showComplement, showIndex, style, zoom } = this.props;
     let { translations } = this.props;
     const { compSeq, seq, seqType } = this.state;
 
@@ -446,6 +451,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
         (() => {
           // do nothing
         }),
+      primers: primers.map((p, i) => ({ color: colorByIndex(i), id: `primer${p.name}${i}${p.start}${p.end}`, ...p })),
       rotateOnScroll: !!this.props.rotateOnScroll,
       showComplement: (!!compSeq && (typeof showComplement !== "undefined" ? showComplement : true)) || false,
       showIndex: !!showIndex,

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -32,7 +32,16 @@ export interface Translation extends NameRange {
   direction: -1 | 1;
 }
 
-/** Primer is a single primer for PCR. Not visualized right now. */
+/** PrimerProp is a single primer to visualize above/below the linear viewer. */
+export interface PrimerProp {
+  color?: string;
+  direction: 1 | -1;
+  end: number;
+  name: string;
+  start: number;
+}
+
+/** Primer is a single primer for PCR. */
 export interface Primer extends NameRange {
   color: string;
   direction: 1 | -1;

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -37,6 +37,7 @@ export interface PrimerProp {
   color?: string;
   direction: 1 | -1;
   end: number;
+  id?: string;
   name: string;
   start: number;
 }

--- a/src/selectionContext.ts
+++ b/src/selectionContext.ts
@@ -1,6 +1,15 @@
 import * as React from "react";
 
-type SelectionTypeEnum = "ANNOTATION" | "FIND" | "TRANSLATION" | "ENZYME" | "SEQ" | "AMINOACID" | "HIGHLIGHT" | "";
+type SelectionTypeEnum =
+  | "ANNOTATION"
+  | "FIND"
+  | "TRANSLATION"
+  | "ENZYME"
+  | "SEQ"
+  | "AMINOACID"
+  | "HIGHLIGHT"
+  | "PRIMER"
+  | "";
 
 /* Selection holds meta about the viewer(s) active selection. */
 export interface Selection {


### PR DESCRIPTION
I made the component to visualize primers (#232).

So far, so good. Some problems I would like to ask for some help.
1. We have a gap between the complementary sequence and the reverse primer line, but we do not have a gap between the forward primer line and the sequence.  
2. When I select a specific area where a forward prime component is rendered, the component is erased. Do you know why? 

![image](https://github.com/Lattice-Automation/seqviz/assets/19381976/8d1432ec-c185-474a-9f26-923eaab0416f)
