### PR TITLE
Added shift select for amino acids, added copy feature for AA

### DIFF
--- a/src/EventHandler.tsx
+++ b/src/EventHandler.tsx
@@ -223,7 +223,7 @@ export class EventHandler extends React.PureComponent<EventsHandlerProps> {
    */
   handleMouseEvent = (e: React.MouseEvent<HTMLDivElement>) => {
     const { handleMouseEvent } = this.props;
-    if(e.shiftKey){
+    if (e.shiftKey) {
       this.handleCopy();
     }
     if (e.type === "mouseup") {

--- a/src/EventHandler.tsx
+++ b/src/EventHandler.tsx
@@ -223,7 +223,9 @@ export class EventHandler extends React.PureComponent<EventsHandlerProps> {
    */
   handleMouseEvent = (e: React.MouseEvent<HTMLDivElement>) => {
     const { handleMouseEvent } = this.props;
-
+    if(e.shiftKey){
+      this.handleCopy();
+    }
     if (e.type === "mouseup") {
       this.resetClicked();
       if (this.clickedOnce === e.target && this.clickedTwice === e.target) {

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -39,7 +39,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
   declare context: React.ContextType<typeof SelectionContext>;
 
   /** Only state is the selection range */
-  state = { ...defaultSelection, aminoAcidShiftStart: null };
+  state = { ...defaultSelection, aminoAcidShiftStart: null, prevAA: null };
 
   /* previous base cursor is over, used in circular drag select */
   previousBase: null | number = null;
@@ -128,7 +128,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
       return; // there isn't a known range with the id of the element
     }
     knownRange = { ...knownRange, end: knownRange.end || 0, start: knownRange.start || 0 };
-
+    
     const { direction, end, start, viewer } = knownRange;
     switch (knownRange.type) {
       case "ANNOTATION":
@@ -173,14 +173,24 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
           selectionEnd = clockwise ? knownRange.end : knownRange.start;
         }
 
+        
+        
         if (e.shiftKey) {
-          if (this.state.aminoAcidShiftStart) {
-            selectionStart = this.state.aminoAcidShiftStart;
-          } else {
-            this.setState({ aminoAcidShiftStart: selectionStart });
+          if(this.state.prevAA && selectionStart){
+            selectionStart = this.state.prevAA 
+            this.setState({ aminoAcidShiftStart: selectionStart});
           }
+          else{
+            if (this.state.aminoAcidShiftStart) {
+              console.log(this.state.aminoAcidShiftStart)
+              selectionStart = this.state.aminoAcidShiftStart;
+            } else {
+              this.setState({ aminoAcidShiftStart: selectionStart });
+            }
+          }
+          
         } else {
-          this.setState({ aminoAcidShiftStart: null });
+          this.setState({ aminoAcidShiftStart: null, prevAA: selectionStart });
         }
 
         this.setSelection({

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -179,7 +179,6 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
             this.setState({ aminoAcidShiftStart: selectionStart });
           } else {
             if (this.state.aminoAcidShiftStart) {
-              console.log(this.state.aminoAcidShiftStart);
               selectionStart = this.state.aminoAcidShiftStart;
             } else {
               this.setState({ aminoAcidShiftStart: selectionStart });

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -128,7 +128,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
       return; // there isn't a known range with the id of the element
     }
     knownRange = { ...knownRange, end: knownRange.end || 0, start: knownRange.start || 0 };
-    
+
     const { direction, end, start, viewer } = knownRange;
     switch (knownRange.type) {
       case "ANNOTATION":
@@ -173,22 +173,18 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
           selectionEnd = clockwise ? knownRange.end : knownRange.start;
         }
 
-        
-        
         if (e.shiftKey) {
-          if(this.state.prevAA && selectionStart){
-            selectionStart = this.state.prevAA 
-            this.setState({ aminoAcidShiftStart: selectionStart});
-          }
-          else{
+          if (this.state.prevAA && selectionStart) {
+            selectionStart = this.state.prevAA;
+            this.setState({ aminoAcidShiftStart: selectionStart });
+          } else {
             if (this.state.aminoAcidShiftStart) {
-              console.log(this.state.aminoAcidShiftStart)
+              console.log(this.state.aminoAcidShiftStart);
               selectionStart = this.state.aminoAcidShiftStart;
             } else {
               this.setState({ aminoAcidShiftStart: selectionStart });
             }
           }
-          
         } else {
           this.setState({ aminoAcidShiftStart: null, prevAA: selectionStart });
         }

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -65,7 +65,6 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
   /** a map between the id of child elements and their associated SelectRanges */
   idToRange = new Map<string, Selection>();
 
-
   componentDidMount = () => {
     if (!document) return;
     document.addEventListener("mouseup", this.stopDrag);
@@ -174,18 +173,15 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
           selectionEnd = clockwise ? knownRange.end : knownRange.start;
         }
 
-        if(e.shiftKey){
-          if(this.state.aminoAcidShiftStart){
-            selectionStart = this.state.aminoAcidShiftStart
-            selectionEnd = selectionEnd
+        if (e.shiftKey) {
+          if (this.state.aminoAcidShiftStart) {
+            selectionStart = this.state.aminoAcidShiftStart;
+            selectionEnd = selectionEnd;
+          } else {
+            this.setState({ aminoAcidShiftStart: selectionStart });
           }
-          else{
-            this.setState({aminoAcidShiftStart: selectionStart})
-          }
-          
-        }
-        else{
-          this.setState({aminoAcidShiftStart: null})
+        } else {
+          this.setState({ aminoAcidShiftStart: null });
         }
 
         this.setSelection({
@@ -209,7 +205,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
           this.handleCircularSeqEvent(e);
         }
 
-        this.setState({aminoAcidShiftStart: null})
+        this.setState({ aminoAcidShiftStart: null });
 
         break;
       }

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -176,7 +176,6 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
         if (e.shiftKey) {
           if (this.state.aminoAcidShiftStart) {
             selectionStart = this.state.aminoAcidShiftStart;
-            selectionEnd = selectionEnd;
           } else {
             this.setState({ aminoAcidShiftStart: selectionStart });
           }

--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -39,7 +39,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
   declare context: React.ContextType<typeof SelectionContext>;
 
   /** Only state is the selection range */
-  state = { ...defaultSelection };
+  state = { ...defaultSelection, aminoAcidShiftStart: null };
 
   /* previous base cursor is over, used in circular drag select */
   previousBase: null | number = null;
@@ -64,6 +64,7 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
 
   /** a map between the id of child elements and their associated SelectRanges */
   idToRange = new Map<string, Selection>();
+
 
   componentDidMount = () => {
     if (!document) return;
@@ -173,6 +174,20 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
           selectionEnd = clockwise ? knownRange.end : knownRange.start;
         }
 
+        if(e.shiftKey){
+          if(this.state.aminoAcidShiftStart){
+            selectionStart = this.state.aminoAcidShiftStart
+            selectionEnd = selectionEnd
+          }
+          else{
+            this.setState({aminoAcidShiftStart: selectionStart})
+          }
+          
+        }
+        else{
+          this.setState({aminoAcidShiftStart: null})
+        }
+
         this.setSelection({
           ...knownRange,
           clockwise: clockwise,
@@ -193,6 +208,8 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
         } else if (viewer === "CIRCULAR") {
           this.handleCircularSeqEvent(e);
         }
+
+        this.setState({aminoAcidShiftStart: null})
 
         break;
       }


### PR DESCRIPTION
Addresses part of issue #213 specifically the following quote:

> Shift-clicking a second amino acid selects every nucleotide between the current selection point and the end of the second amino acid.

Now when a user holds down shift and selects an amino acid they can keep selecting amino acids and SeqViz will create a selection range for the selected AAs.

Additionally I added support for copying the amino acid selection to the clipboard.

I suppose this is more of a feature add than a bug fix, regardless I figured it would be useful.