### PR TITLE
Linear view scrolls to selection when passed by prop

### DIFF
--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -93,7 +93,7 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
 
   // If the selection prop updates, also scroll the lineaer view to the new selection
   componentDidUpdate = (prevProps: SeqViewerContainerProps) => {
-    if (this.props.selection !== prevProps.selection) {
+    if (this.props.selection?.start !== prevProps.selection?.start) {
       this.setCentralIndex("LINEAR", this.props.selection?.start || 0);
     }
   };

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -84,12 +84,19 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     this.state = {
       centralIndex: {
         circular: 0,
-        linear: 0,
+        linear: props?.selection?.start || 0,
         setCentralIndex: this.setCentralIndex,
       },
       selection: this.getSelection(defaultSelection, props.selection),
     };
   }
+
+  // If the selection prop updates, also scroll the lineaer view to the new selection
+  componentDidUpdate = (prevProps: SeqViewerContainerProps) => {
+    if (this.props.selection !== prevProps.selection) {
+      this.setCentralIndex("LINEAR", this.props.selection?.start || 0);    
+    }
+  };
 
   /** this is here because the size listener is returning a new "size" prop every time */
   shouldComponentUpdate = (nextProps: SeqViewerContainerProps, nextState: any) =>

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -94,7 +94,7 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
   // If the selection prop updates, also scroll the lineaer view to the new selection
   componentDidUpdate = (prevProps: SeqViewerContainerProps) => {
     if (this.props.selection !== prevProps.selection) {
-      this.setCentralIndex("LINEAR", this.props.selection?.start || 0);    
+      this.setCentralIndex("LINEAR", this.props.selection?.start || 0);
     }
   };
 


### PR DESCRIPTION
Sets the central index initially to the  prop selection.start, and then if the selection is updated, also updates the index.

One thing  I didn't know was whether to update the central circular index as well. I'm not sure what the use for it, but let me know if I should do it too @jjti 

solves #252 