### PR TITLE
Revert "Linear view scrolls to selection when passed by prop"

### DIFF
--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -84,19 +84,12 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     this.state = {
       centralIndex: {
         circular: 0,
-        linear: props?.selection?.start || 0,
+        linear: 0,
         setCentralIndex: this.setCentralIndex,
       },
       selection: this.getSelection(defaultSelection, props.selection),
     };
   }
-
-  // If the selection prop updates, also scroll the lineaer view to the new selection
-  componentDidUpdate = (prevProps: SeqViewerContainerProps) => {
-    if (this.props.selection?.start !== prevProps.selection?.start) {
-      this.setCentralIndex("LINEAR", this.props.selection?.start || 0);
-    }
-  };
 
   /** this is here because the size listener is returning a new "size" prop every time */
   shouldComponentUpdate = (nextProps: SeqViewerContainerProps, nextState: any) =>


### PR DESCRIPTION
@guzmanvig can you check this out, I think there's a bug in the change to selection logic. When I click a row, now, it jumps to that row immediately. It also doesn't clear an existing highlight so it creates a drag effect

https://github.com/Lattice-Automation/seqviz/assets/13923102/35e9700c-62f6-4a5b-bd12-e9969b66da8e

