### PR TITLE
Crossing zero cut sites

### DIFF
--- a/src/Circular/CutSites.tsx
+++ b/src/Circular/CutSites.tsx
@@ -20,10 +20,8 @@ interface CutSitesProps {
 }
 
 export const CutSites = (props: CutSitesProps) => {
-  let { cutSites } = props;
+  const { cutSites } = props;
   if (!cutSites.length) return null;
-
-  cutSites = cutSites.filter(c => c.end > c.start);
 
   const calculateLinePath = (index: number, startRadius: number, endRadius: number): string => {
     const { findCoor } = props;
@@ -55,13 +53,17 @@ const SingleCutSite = (props: {
   const { id, start } = cutSite;
   let { end, fcut, rcut } = cutSite;
 
-  // crosses the zero index
-  if (start + fcut > end + rcut) {
-    end = start > end ? end + seqLength : end;
-    if (fcut > rcut) {
-      rcut += seqLength;
-    } else {
+  // If any of the end or cut values are greater than the start, it's corssing the zero index
+  if (start > end || start > fcut || start > rcut) {
+    // So add the length of the sequence to all values that are crossing the zero index
+    if (start > end) {
+      end += seqLength;
+    }
+    if (start > fcut) {
       fcut += seqLength;
+    }
+    if (start > rcut) {
+      rcut += seqLength;
     }
   }
 

--- a/src/Linear/CutSites.tsx
+++ b/src/Linear/CutSites.tsx
@@ -40,7 +40,7 @@ export const CutSites = (props: {
     // TODO: remove this exclusion of cut-sites that cross the zero index after even more
     // zero-index accounting. This file is already hairy enough, so not in a rush to add zero-index
     // accounting here, yet.
-    cutSites.filter(c => c.end > c.start),
+    cutSites,
     firstBase,
     lastBase,
     findXAndWidth
@@ -162,9 +162,7 @@ const enhanceCutSites = (
   findXAndWidth: FindXAndWidthType
 ): CutSiteEnhanced[] =>
   cutSites.map((c: CutSite) => {
-    const { x: topX } = findXAndWidth(c.fcut, c.fcut);
-    const { x: bottomX } = findXAndWidth(c.rcut, c.rcut);
-
+    
     // Prevent double rendering of cut-site lines across SeqBlocks. Without the shenanigans below,
     // if a cut site lands on the last or first base of a SeqBlock, it will also render at the end of a SeqBlock
     // and the start of the next. Below, we only show a cut if 1. it's wholly within this SeqBlock or
@@ -184,14 +182,44 @@ const enhanceCutSites = (
       showBottomLine = true;
     }
 
+    // Special case for cut sites that cross the zero index
+    let enhancedCutSite = c;
+    if (c.end < c.start) {
+      // If this is the part of the cut site that is on the last block
+      if (c.start > firstBase && c.start < lastBase) {
+        // Use the last base of the block to close the cut site
+        enhancedCutSite = { ...c, end: lastBase };
+        //If cuts are on the other block, use the last base as cut instead
+        if (c.fcut < c.start) {
+          enhancedCutSite = { ...enhancedCutSite, fcut: lastBase };
+        }
+        if (c.rcut < c.start) {
+          enhancedCutSite = { ...enhancedCutSite, rcut: lastBase };
+        }
+      } else {
+        // This is the part of the cut site that is on the first block, use the first base as the start of the cut site
+        enhancedCutSite = { ...c, start: firstBase };
+        // If cuts are on the other block, use the first base as cut instead
+        if (c.fcut > c.end) {
+          enhancedCutSite = { ...enhancedCutSite, fcut: firstBase };
+        }
+        if (c.rcut > c.end) {
+          enhancedCutSite = { ...enhancedCutSite, rcut: firstBase };
+        }
+      }  
+    }
+
+    const { x: topX } = findXAndWidth(enhancedCutSite.fcut, enhancedCutSite.fcut);
+    const { x: bottomX } = findXAndWidth(enhancedCutSite.rcut, enhancedCutSite.rcut);
+
     return {
       bottom: {
         render: showBottomLine,
         x: bottomX,
       },
       c,
-      connector: calcConnector(c, topX, bottomX, firstBase, lastBase, showTopLine, showBottomLine, findXAndWidth),
-      highlight: calcHighlight(c, firstBase, lastBase, findXAndWidth),
+      connector: calcConnector(enhancedCutSite, topX, bottomX, firstBase, lastBase, showTopLine, showBottomLine, findXAndWidth),
+      highlight: calcHighlight(enhancedCutSite, firstBase, lastBase, findXAndWidth),
       top: {
         render: showTopLine,
         x: topX,

--- a/src/Linear/CutSites.tsx
+++ b/src/Linear/CutSites.tsx
@@ -162,7 +162,6 @@ const enhanceCutSites = (
   findXAndWidth: FindXAndWidthType
 ): CutSiteEnhanced[] =>
   cutSites.map((c: CutSite) => {
-    
     // Prevent double rendering of cut-site lines across SeqBlocks. Without the shenanigans below,
     // if a cut site lands on the last or first base of a SeqBlock, it will also render at the end of a SeqBlock
     // and the start of the next. Below, we only show a cut if 1. it's wholly within this SeqBlock or
@@ -206,7 +205,7 @@ const enhanceCutSites = (
         if (c.rcut > c.end) {
           enhancedCutSite = { ...enhancedCutSite, rcut: firstBase };
         }
-      }  
+      }
     }
 
     const { x: topX } = findXAndWidth(enhancedCutSite.fcut, enhancedCutSite.fcut);
@@ -218,7 +217,16 @@ const enhanceCutSites = (
         x: bottomX,
       },
       c,
-      connector: calcConnector(enhancedCutSite, topX, bottomX, firstBase, lastBase, showTopLine, showBottomLine, findXAndWidth),
+      connector: calcConnector(
+        enhancedCutSite,
+        topX,
+        bottomX,
+        firstBase,
+        lastBase,
+        showTopLine,
+        showBottomLine,
+        findXAndWidth
+      ),
       highlight: calcHighlight(enhancedCutSite, firstBase, lastBase, findXAndWidth),
       top: {
         render: showTopLine,

--- a/src/elementsToRows.ts
+++ b/src/elementsToRows.ts
@@ -159,16 +159,7 @@ export const createSingleRows = <T extends NameRange>(
 
   // assign each element to its respective array
   for (let i = 0; i < elements.length; i += 1) {
-    let { end, start } = elements[i];
-
-    // special case for enzymes that have cut-sites away from recog (BsaI)
-    // @ts-expect-error this is some hack for cut-sites
-    if (elements[i].fcut !== undefined) {
-      // @ts-expect-error this is some hack for cut-sites
-      const { fcut, rcut } = elements[i];
-      start = fcut > end || fcut < start ? fcut : start;
-      end = rcut > end || rcut < start ? rcut : end;
-    }
+    const { end, start } = elements[i];
 
     if (start < end) {
       let k = Math.floor(start / rowLength);


### PR DESCRIPTION
fixes #272 

The logic to handle cut sites is quite complex so I tried to make all the changes encapsulated on an "if cut site crosses the zero-index" as to not mess with the rest of the logic. Tried it with multiple different enzymes.

Here's 2 screenshots:

<img width="1341" alt="Screenshot 2024-09-25 at 12 01 35" src="https://github.com/user-attachments/assets/3d0d328d-4d30-4e4d-963d-348535e91e40">
<img width="1341" alt="Screenshot 2024-09-25 at 12 02 10" src="https://github.com/user-attachments/assets/7e1a3c2c-6d89-4cd4-8166-885a43f00add">
