### PR TITLE
Updated range to be 1-based

### DIFF
--- a/demo/lib/Header.tsx
+++ b/demo/lib/Header.tsx
@@ -74,7 +74,7 @@ const SelectionMetaRow = ({ selection }) => {
           <div className="meta-datum">
             <p id="field">RANGE</p>
             <p id="value">
-              {start} - {end}
+              {start + 1} - {end + 1}
             </p>
           </div>
         )}


### PR DESCRIPTION
Showing a 1-based range to match what the viewer shows.

Mentioned in #278