### PR TITLE
fix: lazy-load react-dom/server to prevent Vite/Rollup crash (#293)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Root, createRoot } from "react-dom/client";
-import { renderToString as reactRenderToString } from "react-dom/server";
 
 import Circular from "./Circular/Circular";
 import Linear from "./Linear/Linear";
@@ -10,7 +9,7 @@ import enzymes from "./enzymes";
 /**
  * Export a React component directly for React-based development
  */
-export { SeqViz, Linear, Circular, enzymes as Enzymes };
+export { Circular, enzymes as Enzymes, Linear, SeqViz };
 
 export default SeqViz;
 
@@ -59,7 +58,12 @@ const Viewer = (element: string | HTMLElement = "root", options: SeqVizProps) =>
    * Return an HTML string representation of the viewer
    */
   const renderToString = () => {
-    return reactRenderToString(viewer);
+    // Lazy-load react-dom/server to avoid eager import at module scope.
+    // react-dom/server depends on Node built-ins (util.TextEncoder) that
+    // crash in Vite/Rollup browser builds. See: #293
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ReactDOMServer = require("react-dom/server");
+    return ReactDOMServer.renderToString(viewer);
   };
 
   /**


### PR DESCRIPTION
Closes #293

### Problem

`import { SeqViz } from "seqviz"` crashes in Vite (and other Rollup-based bundlers) with:

```
Module 'util' has been externalized for browser compatibility.
Cannot access 'util.TextEncoder' in client code.
```

`react-dom/server` was imported at the top level of `src/index.ts`, meaning it was eagerly loaded on *any* import from seqviz — even when the consumer only uses the `<SeqViz>` React component and never calls `renderToString()`. 

`react-dom/server`'s Node build depends on `util.TextEncoder`. Webpack masks this by polyfilling Node built-ins for browser targets, but Vite and Rollup do not — they externalize them, causing the crash.

### Fix

Moved the `react-dom/server` import from module scope into the `renderToString()` closure inside the `Viewer` function. It now only loads when someone actually calls `viewer.renderToString()`.

This uses `require()` instead of a top-level `import` statement, with an eslint-disable comment. This is intentional — a top-level `import` would be hoisted back to module scope by the bundler, reintroducing the bug. The inline comment explains why.

### Who this affects

- **React component users** (`import { SeqViz }`): Bug fixed. No behavior change.
- **Vanilla JS users calling `.render()` / `.setState()`**: No change.
- **Vanilla JS users calling `.renderToString()`**: No behavior change — same result, just loaded at call time instead of import time.
- **CDN users** (`seqviz.min.js`): No change — the minified UMD bundle inlines everything regardless.

### Verification

- Confirmed `__webpack_require__` for `react-dom/server` is no longer at module scope in compiled `dist/index.js`
- All 59 existing tests pass
- Demo app renders and works correctly