### PR TITLE
Moved ref registration to component mount

### DIFF
--- a/src/Linear/SeqBlock.tsx
+++ b/src/Linear/SeqBlock.tsx
@@ -77,9 +77,30 @@ export interface SeqBlockProps {
 export class SeqBlock extends React.PureComponent<SeqBlockProps> {
   static defaultProps = {};
 
+  componentDidMount = () => {
+    this.registerSelf();
+  };
+
+  componentDidUpdate = (prevProps: SeqBlockProps) => {
+    if (prevProps.id !== this.props.id || prevProps.firstBase !== this.props.firstBase) {
+      this.registerSelf();
+    }
+  };
+
   componentWillUnmount = () => {
     const { id, onUnmount } = this.props;
     onUnmount(id);
+  };
+
+  registerSelf = () => {
+    const { firstBase, id, inputRef, seq } = this.props;
+    inputRef(id, {
+      end: firstBase + seq.length,
+      ref: id,
+      start: firstBase,
+      type: "SEQ",
+      viewer: "LINEAR",
+    });
   };
 
   /**
@@ -319,13 +340,6 @@ export class SeqBlock extends React.PureComponent<SeqBlockProps> {
 
     return (
       <svg
-        ref={inputRef(id, {
-          end: lastBase,
-          ref: id,
-          start: firstBase,
-          type: "SEQ",
-          viewer: "LINEAR",
-        })}
         className="la-vz-seqblock"
         cursor="text"
         data-testid="la-vz-seqblock"


### PR DESCRIPTION
fixes #314 

Old behavior:

https://github.com/user-attachments/assets/54f3dceb-41a9-45a3-80a6-8fbf62ccffa0

New behavior:

https://github.com/user-attachments/assets/a92c9648-4667-481d-8f35-08b47bf70051


### The fix

This was analyzed and implemented by Claude. I reviewed and made sense to me. Tested and worked.

Calude's explanation:

---                                                                                                                                
  Root cause: SeqBlock registered itself in SelectionHandler.idToRange via a render-phase side effect — ref={inputRef(id, {...})}    
  called inputRef during JSX evaluation and discarded the undefined return value. In React 19's concurrent mode, the render phase can
   be interrupted and replayed without committing. When InfiniteScroll brings a new block into view via setState, React 19 can:      
  1. Execute the render (side effect fires → block registered)                                                                       
  2. Abort that render for a higher-priority update                                                                                  
  3. Commit the component later — possibly without re-running render, so inputRef never fires again                                  
                                                                                                                                     
  Additionally, React 19's StrictMode double-mount can leave blocks deregistered: componentWillUnmount (simulated) calls onUnmount → 
  removes from idToRange, but if render isn't re-called during the simulated remount, the block stays deregistered. Initially visible
   blocks happen to survive this race because everything settles before user interaction; newly visible blocks (added via a          
  scroll-triggered setState) are more vulnerable.                                                                                    
                                                            
  Fix (src/Linear/SeqBlock.tsx):                                                                                                     
  - Added componentDidMount → calls registerSelf() (fires once after the component is committed to the DOM)
  - Added componentDidUpdate → re-registers if id or firstBase changes                                                               
  - Removed the ref={inputRef(id, {...})} render-phase side effect from the <svg> element
                                                                                                                                     
Registration now happens in the commit phase, which in React 19 is guaranteed to run exactly once per mount and is never           
  interrupted.        

---


Regarding React 18 and others:

---
The old approach (render-phase side effect) also happened to work in React 16/17/18 because:                                       
  - React 16/17: Concurrent mode was experimental and opt-in (ReactDOM.createRoot wasn't the default). Renders were synchronous, so  
  the render phase ran exactly once per commit — the side effect was reliable.                                                       
  - React 18: Concurrent mode became default with createRoot, but in practice the render-abort-replay scenario that breaks the side  
  effect was rare enough for this specific scroll pattern not to surface visibly.                                                    
  - React 19: Concurrent mode scheduling became more aggressive, making the render interruption/replay case much more common, which  
  is why the bug surfaced now.                                                                                                     
                                                                                                                                     
  The new pattern (componentDidMount/componentDidUpdate) is the canonical way to do this and is correct in all React versions — it
  always fires exactly once per committed mount/update, regardless of how many times React chose to run the render phase.  

---




