### PR TITLE
Skipping re registration of linear to circular

### DIFF
--- a/src/SelectionHandler.tsx
+++ b/src/SelectionHandler.tsx
@@ -95,6 +95,16 @@ export default class SelectionHandler extends React.PureComponent<SelectionHandl
    * it stores the id of all elements
    **/
   inputRef = (ref: string, selectRange: Selection) => {
+    // Don't let a LINEAR registration overwrite a CIRCULAR one. When both viewers
+    // are visible, the linear view re-renders with the previous visibleBlocks
+    // (before scrollToCentralIndex updates them), so an annotation that was just
+    // scrolled to in linear briefly re-registers as LINEAR — overwriting the
+    // circular registration. On the next circular click the viewer field is
+    // "LINEAR", which blocks setCentralIndex. Keeping CIRCULAR as the canonical
+    // viewer prevents this.
+    if (selectRange.viewer === "LINEAR" && this.idToRange.get(ref)?.viewer === "CIRCULAR") {
+      return;
+    }
     this.idToRange.set(ref, { ref, ...selectRange });
   };
 


### PR DESCRIPTION
fixes #316 

Before:

https://github.com/user-attachments/assets/f6376303-5201-420b-86f7-7e2e676071de

Now:

https://github.com/user-attachments/assets/9aa75850-1b38-43a4-a1c9-f55ab948c38e

### The fix

This was analyzed and implemented by Claude. I reviewed and made sense to me. Tested and worked.

Calude's explanation:

  Root cause (in SelectionHandler.inputRef):                                            
  - When both circular and linear viewers are visible, an annotation visible in linear  
  gets registered with viewer: "LINEAR", overwriting the circular view's viewer:        
  "CIRCULAR" registration                                                        
  - This happens because when setCentralIndex triggers a re-render, linear re-renders   
  with the old visibleBlocks (before scrollToCentralIndex updates them), re-registering
  the annotation as LINEAR                                                              
  - The subsequent scrollToCentralIndex updates visibleBlocks (dropping the annotation
  from the linear render), but doesn't cause a circular re-render to restore the        
  CIRCULAR registration                                                                 
  - On the next circular click, mouseEvent finds viewer: "LINEAR" → skips
  setCentralIndex → linear doesn't scroll                                               
                                                                                        
  Fix (src/SelectionHandler.tsx): inputRef now skips overwriting a CIRCULAR registration
   with LINEAR. Since removeMountedBlock is never called anywhere, CIRCULAR             
  registrations persist correctly. 
