### PR TITLE
Scroll linear index even when selection doesn't change

### DIFF
--- a/src/Linear/InfiniteScroll.tsx
+++ b/src/Linear/InfiniteScroll.tsx
@@ -16,6 +16,7 @@ interface InfiniteScrollProps {
 
 interface InfiniteScrollState {
   centralIndex: number;
+  scrollToken: number;
   visibleBlocks: number[];
 }
 
@@ -44,6 +45,7 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
 
     this.state = {
       centralIndex: 0,
+      scrollToken: 0,
       // start off with first 5 blocks shown
       visibleBlocks: new Array(Math.min(5, props.seqBlocks.length)).fill(null).map((_, i) => i),
     };
@@ -65,9 +67,9 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
     }
 
     const { seqBlocks, size } = this.props;
-    const { centralIndex, visibleBlocks } = this.state;
+    const { centralIndex, scrollToken, visibleBlocks } = this.state;
 
-    if (this.context && centralIndex !== this.context.linear) {
+    if (this.context && (centralIndex !== this.context.linear || scrollToken !== this.context.linearScrollToken)) {
       this.scrollToCentralIndex();
     } else if (!isEqual(prevProps.size, size) || seqBlocks.length !== prevProps.seqBlocks.length) {
       this.handleScrollOrResize(); // reset
@@ -154,12 +156,16 @@ export class InfiniteScroll extends React.PureComponent<InfiniteScrollProps, Inf
       this.scroller.current.scrollTop = centerBlock.props.y - blockHeights[0] / 2;
     }
 
-    if (!isEqual(newVisibleBlocks, visibleBlocks)) {
-      this.setState({
-        centralIndex: centralIndex,
-        visibleBlocks: newVisibleBlocks,
-      });
+    // Always sync centralIndex and scrollToken so componentDidUpdate doesn't
+    // re-trigger scrollToCentralIndex on the next render.
+    const newState: Partial<InfiniteScrollState> = {
+      centralIndex: centralIndex,
+      scrollToken: this.context.linearScrollToken,
+    };
+    if (!isEqual(newVisibleBlocks, visibleBlocks) && newVisibleBlocks.length > 0) {
+      newState.visibleBlocks = newVisibleBlocks;
     }
+    this.setState(newState as InfiniteScrollState);
   };
 
   /**

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -102,10 +102,7 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     if (this.selectionIsProgramatic(this.props.selection)) {
       const sel = this.props.selection;
       const prevSel = prevProps.selection;
-      if (
-        (sel?.start !== prevSel?.start || sel?.end !== prevSel?.end) &&
-        sel?.start !== sel?.end
-      ) {
+      if ((sel?.start !== prevSel?.start || sel?.end !== prevSel?.end) && sel?.start !== sel?.end) {
         this.setCentralIndex("LINEAR", sel?.start || 0);
       }
     }

--- a/src/SeqViewerContainer.tsx
+++ b/src/SeqViewerContainer.tsx
@@ -64,6 +64,7 @@ export interface SeqViewerContainerState {
   centralIndex: {
     circular: number;
     linear: number;
+    linearScrollToken: number;
     setCentralIndex: (type: "LINEAR" | "CIRCULAR", value: number) => void;
   };
   selection: Selection;
@@ -81,6 +82,7 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
       centralIndex: {
         circular: 0,
         linear: 0,
+        linearScrollToken: 0,
         setCentralIndex: this.setCentralIndex,
       },
       selection: this.getSelection(defaultSelection, props.selection),
@@ -98,11 +100,13 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
     // Only scroll if the selection was done passed in as a prop by a user of SeqViz. Otherwise the selection was
     // made by the user clicking an element or selecting a range of sequences
     if (this.selectionIsProgramatic(this.props.selection)) {
+      const sel = this.props.selection;
+      const prevSel = prevProps.selection;
       if (
-        this.props.selection?.start !== prevProps.selection?.start &&
-        this.props.selection?.start !== this.props.selection?.end
+        (sel?.start !== prevSel?.start || sel?.end !== prevSel?.end) &&
+        sel?.start !== sel?.end
       ) {
-        this.setCentralIndex("LINEAR", this.props.selection?.start || 0);
+        this.setCentralIndex("LINEAR", sel?.start || 0);
       }
     }
   };
@@ -119,11 +123,23 @@ class SeqViewerContainer extends React.Component<SeqViewerContainerProps, SeqVie
       throw new Error(`Unknown central index type: ${type}`);
     }
 
-    if (this.state.centralIndex[type.toLowerCase()] === value) {
-      return; // nothing changed
+    if (type === "LINEAR") {
+      // Always update and increment the scroll token so InfiniteScroll scrolls
+      // even when the target position hasn't changed (e.g. re-clicking the same
+      // annotation after manually scrolling the linear view away).
+      this.setState({
+        centralIndex: {
+          ...this.state.centralIndex,
+          linear: value,
+          linearScrollToken: this.state.centralIndex.linearScrollToken + 1,
+        },
+      });
+    } else {
+      if (this.state.centralIndex.circular === value) {
+        return; // nothing changed
+      }
+      this.setState({ centralIndex: { ...this.state.centralIndex, circular: value } });
     }
-
-    this.setState({ centralIndex: { ...this.state.centralIndex, [type.toLowerCase()]: value } });
   };
 
   /**

--- a/src/centralIndexContext.ts
+++ b/src/centralIndexContext.ts
@@ -4,6 +4,8 @@ import * as React from "react";
 const defaultCentralIndex = {
   circular: 0,
   linear: 0,
+  /** Incremented each time an explicit scroll-to-linear is requested, even if the position hasn't changed */
+  linearScrollToken: 0,
   setCentralIndex: (_: "LINEAR" | "CIRCULAR", __: number) => {
     // do nothing
   },


### PR DESCRIPTION
fixes #323 

This fixes the following issue: If there is a selection, and the user scroll away from it in the linear view, selecting the same thing again (e.g.: clicking on the same annotation or setting it programatically) didn't cause the linear view to scroll back to it.

Moreover, because view scrolls to the start of the selection, if the selection was changed programatically to another selection with the same start but different end, it didn't scroll either.

This solves the issue by adding a "token" that changes everytime a scroll is requested, regardless of the start position.