### PR TITLE
Fixes mapping of annotation end

### DIFF
--- a/src/Linear/Linear.tsx
+++ b/src/Linear/Linear.tsx
@@ -104,6 +104,7 @@ export default class Linear extends React.Component<LinearProps> {
      */
     function vetAnnotations<T extends NameRange>(annotations: T[]): T[] {
       annotations.forEach(ann => {
+        if (ann.end > seqLength) ann.end = ann.end % seqLength;
         if (ann.end === 0 && ann.start > ann.end) ann.end = seqLength;
         if (ann.start === seqLength && ann.end < ann.start) ann.start = 0;
       });

--- a/src/SeqViz.tsx
+++ b/src/SeqViz.tsx
@@ -410,7 +410,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
       ...a,
       color: a.color || colorByIndex(i, COLORS),
       direction: directionality(a.direction),
-      end: a.end % (seq.length + 1),
+      end: a.end > seq.length ? a.end % seq.length : a.end,
       start: a.start % (seq.length + 1),
     }));
 
@@ -439,7 +439,7 @@ export default class SeqViz extends React.Component<SeqVizProps, SeqVizState> {
         (h, i): Highlight => ({
           ...h,
           direction: 1,
-          end: h.end % (seq.length + 1),
+          end: h.end > seq.length ? h.end % seq.length : h.end,
           id: `highlight-${i}-${h.start}-${h.end}`,
           name: "",
           start: h.start % (seq.length + 1),


### PR DESCRIPTION
fixes #327 

When annotations, primers, and highlights wrap around the zero index, we were one nucleotide off. Very interesting we didn't caught this before. @jjti any thoughts?

Example:

This sequence of 20 nucleotides, and the follwing annotations and primers are applied. What's expected is that `test2` covers the first bp, and `test3` covers the first and second bp.

```
annotations={[
      { name: "test1", start: 10, end: 20 },
      { name: "test2", start: 10, end: 21 },
      { name: "test3", start: 10, end: 22 },
    ]}
    primers={[
      { direction: 1, name: "test1", start: 10, end: 20 },
      { direction: 1, name: "test2", start: 10, end: 21 },
      { direction: 1, name: "test3", start: 10, end: 22 },
    ]}
```

This is before this PR:

<img width="239" height="191" alt="image" src="https://github.com/user-attachments/assets/4fba3215-f502-48eb-a5db-7f07af78b557" />

(test1 and and test2 are the same, and test 3 is missing the last bp)

This is after this PR:

<img width="239" height="191" alt="image" src="https://github.com/user-attachments/assets/3eb5cb8f-7e67-4ae4-ab78-60acc2d9f218" />
