### PR TITLE
Avoid repeated work when displaying long proteins

### DIFF
--- a/src/Linear/Translations.test.tsx
+++ b/src/Linear/Translations.test.tsx
@@ -1,0 +1,77 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+import * as React from "react";
+
+import { SeqType, Translation } from "../elements";
+import { createTranslations } from "../sequence";
+import { TranslationRows } from "./Translations";
+
+const renderRow = (translation: Translation, seq: string, firstBase: number, lastBase: number, seqType: SeqType) => {
+  const refs = new Map();
+  const row = (yDiff = 0) => (
+    <React.StrictMode>
+      <svg>
+        <TranslationRows
+          bpsPerBlock={lastBase - firstBase}
+          charWidth={10}
+          elementHeight={16}
+          findXAndWidth={start => ({ width: 10, x: ((start ?? 0) - firstBase) * 10 })}
+          findXAndWidthElement={() => ({ overflowLeft: false, overflowRight: false, width: 100, x: 0 })}
+          firstBase={firstBase}
+          fullSeq={seq}
+          inputRef={(id, range) => {
+            refs.set(id, range);
+          }}
+          lastBase={lastBase}
+          seqType={seqType}
+          translationRows={[[translation]]}
+          yDiff={yDiff}
+          onUnmount={id => {
+            refs.delete(id);
+          }}
+        />
+      </svg>
+    </React.StrictMode>
+  );
+  return { ...render(row()), refs, row };
+};
+
+afterEach(() => jest.restoreAllMocks());
+
+it("processes only the protein row and reuses its residue IDs", () => {
+  const seq = "ACDEFGHIKLMNPQRSTVWY".repeat(30);
+  const split = jest.spyOn(String.prototype, "split");
+  const random = jest.spyOn(Math, "random");
+  const translation = { AAseq: seq, direction: 1 as const, end: seq.length, id: "protein", name: "", start: 0 };
+  const { container, refs, rerender, row, unmount } = renderRow(translation, seq, 201, 241, "aa");
+
+  expect(container.textContent).toBe(seq.slice(201, 241));
+  // The original renderer split the whole protein and allocated an ID for every residue.
+  expect(split.mock.contexts.map(String)).not.toContain(seq);
+  expect(random).toHaveBeenCalledTimes(40);
+  const residues = Array.from(refs).filter(([id]) => id !== "protein");
+  expect(residues.every(([, range]) => range.type === "AMINOACID" && range.parent?.type === "TRANSLATION")).toBe(true);
+  expect(residues.map(([, range]) => [range.start, range.end])).toEqual(
+    Array.from({ length: 40 }, (_, i) => [201 + i, 202 + i]),
+  );
+  rerender(row(16));
+  expect(random).toHaveBeenCalledTimes(40);
+  expect(Array.from(refs).filter(([id]) => id !== "protein")).toEqual(residues);
+  unmount();
+  expect(residues.filter(([id]) => refs.has(id))).toEqual([]);
+});
+
+it.each(["dna", "rna"] as SeqType[])("keeps partial %s codons at row boundaries", seqType => {
+  const seq = "ATGCCCGGGT".repeat(3).replace(/T/g, seqType === "rna" ? "U" : "T");
+  const [translation] = createTranslations([{ direction: -1, end: 27, id: "cds", name: "", start: 3 }], seq, seqType);
+  const { container, refs } = renderRow({ ...translation, direction: -1 }, seq, 7, 17, seqType);
+  expect(container.textContent).toBe(translation.AAseq.slice(1, 5));
+  const codons = Array.from(refs).filter(([id]) => id !== "cds");
+  expect(codons.map(([, range]) => [range.start, range.end])).toEqual([
+    [6, 9],
+    [9, 12],
+    [12, 15],
+    [15, 18],
+  ]);
+});

--- a/src/Linear/Translations.tsx
+++ b/src/Linear/Translations.tsx
@@ -128,7 +128,7 @@ interface SingleNamedElementAminoacidsProps {
  * see the resulting protein or peptide sequence in the viewer
  */
 class SingleNamedElementAminoacids extends React.PureComponent<SingleNamedElementAminoacidsProps> {
-  AAs: string[] = [];
+  AAs = new Map<number, string>();
 
   // on unmount, clear all AA references.
   componentWillUnmount = () => {
@@ -175,9 +175,11 @@ class SingleNamedElementAminoacids extends React.PureComponent<SingleNamedElemen
     // otherwise, each amino-acid covers three bases.
     const bpPerBlockCount = seqType === "aa" ? 1 : 3;
 
-    // substring and split only the amino acids that are relevant to this
-    // particular sequence block
-    const AAs = AAseq.split("");
+    // Keep absolute residue indexes when slicing to this row, including partial codons.
+    // Wrapped translations retain the circular coordinate handling below.
+    const firstAA = start < end ? Math.max(0, Math.floor((firstBase - start) / bpPerBlockCount)) : 0;
+    const lastAA = start < end ? Math.max(0, Math.ceil((lastBase - start) / bpPerBlockCount)) : AAseq.length;
+    const AAs = AAseq.slice(firstAA, lastAA).split("");
     return (
       <g
         ref={inputRef(id, {
@@ -193,10 +195,8 @@ class SingleNamedElementAminoacids extends React.PureComponent<SingleNamedElemen
         id={id}
         transform={`translate(0, ${y})`}
       >
-        {AAs.map((a, i) => {
-          // generate and store an id reference (that's used for selection)
-          const aaId = randomID();
-          this.AAs.push(aaId);
+        {AAs.map((a, offset) => {
+          const i = firstAA + offset;
 
           // calculate the start and end point of each amino acid
           // modulo needed here for translations that cross zero index
@@ -222,6 +222,13 @@ class SingleNamedElementAminoacids extends React.PureComponent<SingleNamedElemen
           // the amino acid doesn't fit within this SeqBlock (even partially)
           if (AAStart >= lastBase || AAEnd <= firstBase) return null;
 
+          // Allocate IDs only for rendered residues and reuse them across updates.
+          let aaId = this.AAs.get(i);
+          if (!aaId) {
+            aaId = randomID();
+            this.AAs.set(i, aaId);
+          }
+
           let showAminoAcidLabel = true; // whether to show amino acids abbreviation
           let bpCount = bpPerBlockCount; // start off assuming the full thing is shown
           if (AAStart < firstBase) {
@@ -246,13 +253,17 @@ class SingleNamedElementAminoacids extends React.PureComponent<SingleNamedElemen
           return (
             <g
               key={aaId}
-              ref={inputRef(aaId, {
-                end: AAEnd,
-                parent: { ...translation, type: "TRANSLATION" },
-                start: AAStart,
-                type: "AMINOACID",
-                viewer: "LINEAR",
-              })}
+              ref={node => {
+                // Register on mount, including StrictMode's simulated remount.
+                if (node)
+                  inputRef(aaId, {
+                    end: AAEnd,
+                    parent: { ...translation, type: "TRANSLATION" },
+                    start: AAStart,
+                    type: "AMINOACID",
+                    viewer: "LINEAR",
+                  });
+              }}
               id={aaId}
               transform={`translate(${x}, 0)`}
             >


### PR DESCRIPTION
Displaying long proteins is slow because each visible row processes the entire protein sequence, including residues it never draws.

This limits non-wrapping translations to the residues in the current row and reuses their click-target IDs when redrawing. A row showing 40 residues from a 600-residue protein now processes 40 instead of 600.
